### PR TITLE
Fixed logging in multiple packets

### DIFF
--- a/main/utilities/include/log.h
+++ b/main/utilities/include/log.h
@@ -21,16 +21,16 @@ void print_banner();
 // Use these!
 
 #define logln_info(f_, ...) \
-    _log("[INFO] "); logln((f_), ##__VA_ARGS__);
+    logln("[INFO] %s", (f_), ##__VA_ARGS__);
 
 #define logln_warn(f_, ...) \
-    _log("[WARN] "); logln((f_), ##__VA_ARGS__);
+    logln("[WARN] %s", (f_), ##__VA_ARGS__);
 
 #define logln_error(f_, ...) \
-    _log("[ERROR] "); logln((f_), ##__VA_ARGS__);
+    logln("[ERROR] %s", (f_), ##__VA_ARGS__);
 
 #define logln(f_, ...) \
-    _log((f_), ##__VA_ARGS__); _log("\n");
+    _log("%s\n", (f_), ##__VA_ARGS__);
 
 /* INTERNAL FUNCTIONS */
 


### PR DESCRIPTION
Left log funcs to use multiple log calls as it used to be fine when just printing to serial port, obviously not good now to  send multiple packets 