### PR TITLE
Heartbeat tlm logging and playback

### DIFF
--- a/docs/DOCS.md
+++ b/docs/DOCS.md
@@ -16,6 +16,7 @@
   - [Users Guide](#users-guide)
     - [Cloning and Building](#cloning-and-building)
     - [Debugging](#debugging)
+    - [Using the Simulator](#using-the-simulator)
     - [Creating Device Drivers](#creating-device-drivers)
     - [Creating Telemetry Points](#creating-telemetry-points)
     - [Creating New STEVE Jobs](#creating-new-steve-jobs)
@@ -164,6 +165,14 @@ For debugging, you have two options:
    3. You will see any output from `logln_info` and `printf` calls in your code
 2. Debugging through SWD/JTAG
    1. See `debug/README.md` to use the VSCode graphic debugger to set breakpoints and see variable values as your code executes
+
+### Using the Simulator
+
+The simulator will simulate FreeRTOS as well as many pico sdk functions, you can see the implemented pico-sdk functions and change their simulated implementations under main/simulator/pico-sdk. The filesystem is also fully functional in the simulator. You can start the simulator using the "Coconut Simulator Debug" under the VSCode debugging window.
+To utilize telemetry and commands on the simulator with the host computer, the following can be done:
+* In a terminal, run `socat -d -d pty,raw,echo=0 pty,raw,echo=0` - this will create 2 /dev/pts/ ports, which will route each others' inputs to the output of the other
+* Once the simulator executable is built (can be done with `./deploy.sh -b -s`), you can run `./build/Simulator/main/COCONUTFSW > /dev/pts/{x} < /dev/pts/{x}` where {x} is the number of one of the ports created above
+* You can then use any other program to read and write to the *other* pts port just like you would a UDP or serial port 
 
 ### Creating Device Drivers
 

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SOURCES
     ${MAIN_DIRECTORY}/utilities/src/log.c
     ${MAIN_DIRECTORY}/utilities/src/timing.c
     ${MAIN_DIRECTORY}/utilities/src/user_auth.c
+    ${MAIN_DIRECTORY}/utilities/src/hb_tlm_log.c
 
     ${MAIN_DIRECTORY}/drivers/src/i2c.c
     ${MAIN_DIRECTORY}/drivers/src/ina219.c

--- a/main/tasks/command/command.c
+++ b/main/tasks/command/command.c
@@ -127,7 +127,7 @@ void parse_command_packet(spacepacket_header_t header, uint8_t* payload_buf, uin
         case MCU_POWER_CYCLE:
             watchdog_freeze(); // Freezing the watchdog will cause a reboot within a few seconds
             break;
-        case PLAYBACK_PACKETS:
+        case PLAYBACK_HEARTBEAT_PACKETS:
             if (payload_size < sizeof(playback_hb_tlm_payload_t)) break; // Should probably return an error to the ground
             playback_hb_tlm_payload_t* playback_hb_payload = (playback_hb_tlm_payload_t*)payload_buf;
             hb_tlm_playback(playback_hb_payload);

--- a/main/tasks/command/command.c
+++ b/main/tasks/command/command.c
@@ -16,6 +16,7 @@
 #include "filesystem.h"
 #include "command.h"
 #include "watchdog.h"
+#include "hb_tlm_log.h"
 
 void receive_command_byte_from_isr(char ch) {
     // ONLY USE FROM INTERRUPTS, CREATE NEW METHOD FOR QUEUEING CMD BYTES FROM TASKS
@@ -125,6 +126,11 @@ void parse_command_packet(spacepacket_header_t header, uint8_t* payload_buf, uin
             break;
         case MCU_POWER_CYCLE:
             watchdog_freeze(); // Freezing the watchdog will cause a reboot within a few seconds
+            break;
+        case PLAYBACK_PACKETS:
+            if (payload_size < sizeof(playback_hb_tlm_payload_t)) break; // Should probably return an error to the ground
+            playback_hb_tlm_payload_t* playback_hb_payload = (playback_hb_tlm_payload_t*)payload_buf;
+            hb_tlm_playback(playback_hb_payload);
             break;
         default:
             logln_error("Received command with unknown APID: %hu", header.apid);

--- a/main/tasks/command/command.h
+++ b/main/tasks/command/command.h
@@ -25,7 +25,7 @@ typedef enum command_apid {
     ADD_USER = 12,
     DELETE_USER = 13,
     MCU_POWER_CYCLE = 14,
-    PLAYBACK_PACKETS = 15,
+    PLAYBACK_HEARTBEAT_PACKETS = 15,
 } command_apid_t;
 
 typedef struct __attribute__((__packed__)) {

--- a/main/tasks/command/command.h
+++ b/main/tasks/command/command.h
@@ -25,6 +25,7 @@ typedef enum command_apid {
     ADD_USER = 12,
     DELETE_USER = 13,
     MCU_POWER_CYCLE = 14,
+    PLAYBACK_PACKETS = 15,
 } command_apid_t;
 
 typedef struct __attribute__((__packed__)) {
@@ -86,6 +87,12 @@ typedef struct __attribute__((__packed__)) {
     uint16_t data_len;
     uint8_t data[];
 } upload_user_data_t;
+
+typedef struct __attribute__((__packed__)) {
+    uint16_t number_of_packets;
+    uint16_t every_x_packet; // Used to adjust for less resolution but cover more time
+    uint16_t go_back_x_packets; // Used to start the playback from a certain point in the past
+} playback_hb_tlm_payload_t;
 
 // Internal Command Thread Structs
 QueueHandle_t command_byte_queue;

--- a/main/tasks/filesystem/filesystem.c
+++ b/main/tasks/filesystem/filesystem.c
@@ -256,6 +256,8 @@ int32_t _fwrite(const char* file_name, const uint8_t *data, size_t size, bool ap
     FRESULT fr;
     FIL fil;
 
+    logln_info("Writing to file: %s\n", file_name);
+
     int file_open_flags = FA_WRITE | FA_CREATE_ALWAYS;
     if (append_flag) { file_open_flags = FA_OPEN_APPEND | FA_WRITE; }
 

--- a/main/tasks/steve/jobs/heartbeat_job.c
+++ b/main/tasks/steve/jobs/heartbeat_job.c
@@ -160,7 +160,6 @@ void heartbeat_telemetry_job(void* unused) {
     payload.sx_state = radio_get_SX_state(); 
     
     // Send it
-    logln_info("Telem size: %d", sizeof(payload));
     send_telemetry(HEARTBEAT, (char*)&payload, sizeof(payload));
     log_heartbeat_tlm(payload);
 

--- a/main/tasks/steve/jobs/heartbeat_job.c
+++ b/main/tasks/steve/jobs/heartbeat_job.c
@@ -166,14 +166,5 @@ void heartbeat_telemetry_job(void* unused) {
 
     iteration_counter += 1;
 
-    // Test playback
-    if (iteration_counter == 30) {
-        playback_hb_tlm_payload_t playback_payload = {10, 2, 0};
-        int status = hb_tlm_playback(playback_payload);
-        logln_info("HB playback status: %d", status);
-    } else {
-        logln_info("Heartbeat iteration: %d", iteration_counter);
-    }
-
     logln_info("Heartbeat %ld - uptime: %d", iteration_counter, (uint32_t)get_uptime());
 }

--- a/main/tasks/steve/jobs/heartbeat_job.c
+++ b/main/tasks/steve/jobs/heartbeat_job.c
@@ -1,4 +1,5 @@
 #include <stdint.h>
+#include <stdio.h>
 
 #include "FreeRTOS.h"
 #include "queue.h"
@@ -14,6 +15,67 @@
 #include "heartbeat_job.h"
 #include "radio.h"
 #include "max17048.h"
+#include "filesystem.h"
+
+// Size (bytes) that a heartbeat telemetry file can be until a new one should be used
+// If writing a new telemetry entry causes the file to go over this amount, a new file is made
+#define MAX_HB_TLM_FILE_SIZE 200
+
+/* 
+*  Keep a /tlm directory where:
+*  - /tlm/file_counter.bin file contains the index of the next file to be created - 2 bytes
+*  - /tlm/0.bin, /tlm/1.bin, ... /tlm/65535 files contain the telemetry data, most recent of which is the number.bin contained in the file_counter.txt file
+*/
+void log_heartbeat_tlm(heartbeat_telemetry_t payload) {
+
+    // See if tlm directory exists
+    if (!dir_exists("/tlm")) {
+        make_dir("/tlm");
+    }
+    // See if f_count.bin exists, if not create it and start the index at 0
+    if (!file_exists("/tlm/f_count.bin")) {
+        // If the directory exists but the file counter file doesn't, create it and write a 0 to it
+        //touch("/tlm/f_count.bin");
+
+        char data[] = {0, 0};
+        write_file("/tlm/f_count.bin", data, 2, false); // create and write 0 to the file_counter.txt file
+
+        logln_info("TLM dir:");
+        list_dir("/tlm");
+    }
+
+    // Read the file counter
+    char file_counter_buf[2];
+    size_t bytes_read = read_file("/tlm/f_count.bin", file_counter_buf, sizeof(file_counter_buf));
+    if (bytes_read != 2) {
+        logln_error("Error reading f_count.bin");
+        return;
+    }
+
+    uint16_t file_count = (file_counter_buf[0] << 8) | file_counter_buf[1];
+    logln_info("Heartbeat tlm file count: %d", file_count);
+    
+    // Write to this indexed file
+    char filename[20];
+    snprintf(filename, sizeof(filename), "%d.bin", file_count);
+    logln_info("Writing to file: %s", filename);
+    write_file(filename, (char*)&payload, sizeof(payload), true); // append - this will eaither make the file if it does not exist or append to it if it does
+
+    // Check file size to see if it is time to make a new file. If writing another hb to the file makes it go over the limit, 
+    FILINFO file_info;
+    stat(filename, &file_info);
+    if (file_info.fsize + sizeof(heartbeat_telemetry_t) > MAX_HB_TLM_FILE_SIZE) {
+        // Increase f_count.bin by 1 for next time
+        file_count += 1;
+        char new_file_counter_buf[2] = {(file_count >> 8) & 0xFF, file_count & 0xFF};
+        write_file("/tlm/f_count.bin", new_file_counter_buf, 2, false); // overwrite the file counter with the new value
+        logln_info("New tlm file should be created");
+    }
+
+    logln_info("\nTLM DIR:");
+    list_dir("/tlm");
+    
+}
 
 void heartbeat_telemetry_job(void* unused) {
     // Create heartbeat struct
@@ -77,10 +139,10 @@ void heartbeat_telemetry_job(void* unused) {
     if(!getPower_raw(i2c, INA0_ADDR, &ina0buf)) payload.ina0_power = ina0buf;
     else payload.ina0_power = UINT16_MAX; 
 
-    logln_info("INA0 shunt: %ld", payload.ina0_shunt);
+    /*logln_info("INA0 shunt: %ld", payload.ina0_shunt);
     logln_info("INA0 vbus: %ld", payload.ina0_vbus);
     logln_info("INA0 current: %ld", payload.ina0_current);
-    logln_info("INA0 power: %ld", payload.ina0_power);
+    logln_info("INA0 power: %ld", payload.ina0_power);*/
 
     // ina1 data
     uint16_t ina1buf;
@@ -160,6 +222,7 @@ void heartbeat_telemetry_job(void* unused) {
     // Send it
     logln_info("Telem size: %d", sizeof(payload));
     send_telemetry(HEARTBEAT, (char*)&payload, sizeof(payload));
+    log_heartbeat_tlm(payload);
 
     iteration_counter += 1;
     logln_info("Heartbeat %ld - uptime: %d", iteration_counter, (uint32_t)get_uptime());

--- a/main/tasks/steve/jobs/heartbeat_job.c
+++ b/main/tasks/steve/jobs/heartbeat_job.c
@@ -162,14 +162,17 @@ void heartbeat_telemetry_job(void* unused) {
     // Send it
     logln_info("Telem size: %d", sizeof(payload));
     send_telemetry(HEARTBEAT, (char*)&payload, sizeof(payload));
-    //log_heartbeat_tlm(payload);
+    log_heartbeat_tlm(payload);
 
     iteration_counter += 1;
 
     // Test playback
-    if (iteration_counter == 10) {
-        //playback_hb_tlm_payload_t playback_payload = {10, 1, 0};
-        //hb_tlm_playback(playback_payload);
+    if (iteration_counter == 30) {
+        playback_hb_tlm_payload_t playback_payload = {10, 2, 0};
+        int status = hb_tlm_playback(playback_payload);
+        logln_info("HB playback status: %d", status);
+    } else {
+        logln_info("Heartbeat iteration: %d", iteration_counter);
     }
 
     logln_info("Heartbeat %ld - uptime: %d", iteration_counter, (uint32_t)get_uptime());

--- a/main/tasks/steve/jobs/heartbeat_job.h
+++ b/main/tasks/steve/jobs/heartbeat_job.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #define HEARTBEAT_JOB_NAME "heartbeat_telemetry"
-#define HEARTBEAT_TELEMETRY_DEFAULT_INTERVAL 1
+#define HEARTBEAT_TELEMETRY_DEFAULT_INTERVAL 10
 
 uint32_t iteration_counter;
 

--- a/main/tasks/steve/jobs/heartbeat_job.h
+++ b/main/tasks/steve/jobs/heartbeat_job.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #define HEARTBEAT_JOB_NAME "heartbeat_telemetry"
-#define HEARTBEAT_TELEMETRY_DEFAULT_INTERVAL 5
+#define HEARTBEAT_TELEMETRY_DEFAULT_INTERVAL 1
 
 uint32_t iteration_counter;
 

--- a/main/tasks/telemetry/telemetry.h
+++ b/main/tasks/telemetry/telemetry.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "FreeRTOS.h" // This is needed because it gets included from "hb_tlm_log.h" before anything with an '#include "FreeRTOS.h"' is included for some reason
 #include "queue.h"
 
 #define TELEMETRY_SYNC_BYTES "\x35\x2E\xF8\x53"

--- a/main/tasks/telemetry/telemetry.h
+++ b/main/tasks/telemetry/telemetry.h
@@ -16,7 +16,8 @@ typedef enum {
     LOG = 0,
     HEARTBEAT = 1, // just to keep the command and telemetry apid equal :)
     DOWNLINK_GROUNDNODE_DATA = 2, 
-    DOWNLINK_TELEMETRY_DATA = 3
+    DOWNLINK_TELEMETRY_DATA = 3,
+    HEARTBEAT_PLAYBACK = 4,
 } telemetry_apid_t;
 
 typedef struct __attribute__((__packed__)) {

--- a/main/utilities/include/hb_tlm_log.h
+++ b/main/utilities/include/hb_tlm_log.h
@@ -1,55 +1,6 @@
 #pragma once
+#include "telemetry.h"
 #include <stdint.h>
-//#include "telemetry.h"
-
-typedef struct __attribute__((__packed__)) {
-    uint8_t state;
-    uint32_t uptime;
-    uint8_t hour;
-    uint8_t minute;
-    uint8_t second;
-    uint8_t month;
-    uint8_t date;
-    uint8_t year;
-    float rtcTemp; 
-    uint16_t ina0_shunt;
-    uint16_t ina0_vbus;
-    uint16_t ina0_power;
-    uint16_t ina0_current;
-    uint16_t ina1_shunt; 
-    uint16_t ina1_vbus;
-    uint16_t ina1_power;
-    uint16_t ina1_current;
-    uint16_t ina2_shunt; 
-    uint16_t ina2_vbus;
-    uint16_t ina2_power;
-    uint16_t ina2_current;
-    uint16_t ina3_shunt; 
-    uint16_t ina3_vbus;
-    uint16_t ina3_power;
-    uint16_t ina3_current;
-    uint16_t ina4_shunt; 
-    uint16_t ina4_vbus;
-    uint16_t ina4_power;
-    uint16_t ina4_current;
-    uint16_t ina5_shunt; 
-    uint16_t ina5_vbus;
-    uint16_t ina5_power;
-    uint16_t ina5_current;
-    float max17048Voltage;
-    float max17048Percentage;
-    int16_t mag_x;
-    int16_t mag_y;
-    int16_t mag_z;
-    int16_t mag_temp;
-    uint8_t vega_ant_status;
-
-    int16_t rfm_state; 
-    int16_t sx_state; 
-    uint8_t which_radio; // 1 for RFM
-} heartbeat_telemetry2_t;
-
-
 
 // Contents of f_info.bin file which keeps track of information about the logging size and files for the heartbeat tlm in the /tlm directory
 typedef struct HBTlmFilesInfo {
@@ -63,7 +14,7 @@ typedef struct HBTlmFilesInfo {
 *  - /tlm/file_counter.bin file contains the index of the next file to be created - 2 bytes
 *  - /tlm/0.bin, /tlm/1.bin, ... /tlm/65535 files contain the telemetry data, most recent of which is the number.bin contained in the file_counter.txt file
 */
-void log_heartbeat_tlm(heartbeat_telemetry2_t payload);
+void log_heartbeat_tlm(heartbeat_telemetry_t payload);
 
 // Command payload for the playback heartbeat telemetry command
 typedef struct PlaybackHBTLMPayload {
@@ -76,6 +27,6 @@ typedef struct PlaybackHBTLMPayload {
 *  Command for playing back the heartbeat telemetry logs
 *  - Goes through each file, aquiring packets until number_of_packets at intervals of every_x_packet
 *  - If go_back_x_packets is 0, it will begin at the most recently logged packet, otherwise it will traverse back go_back_x_packets packets first before collecting packets
-*  - Returns 0 on success, 1 on missing tlm directory, 2 on f_info.bin read error
+*  - Returns 0 on success, 1 on missing tlm directory, 2 on f_info.bin read error, 5 on reached end of logs
 */
 int hb_tlm_playback(playback_hb_tlm_payload_t playback_payload);

--- a/main/utilities/include/hb_tlm_log.h
+++ b/main/utilities/include/hb_tlm_log.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "telemetry.h"
 #include <stdint.h>
+#include "command.h"
 
 // Contents of f_info.bin file which keeps track of information about the logging size and files for the heartbeat tlm in the /tlm directory
 typedef struct HBTlmFilesInfo {
@@ -16,12 +17,6 @@ typedef struct HBTlmFilesInfo {
 */
 void log_heartbeat_tlm(heartbeat_telemetry_t payload);
 
-// Command payload for the playback heartbeat telemetry command
-typedef struct PlaybackHBTLMPayload {
-    uint16_t number_of_packets;
-    uint16_t every_x_packet; // Used to adjust for less resolution but cover more time
-    uint16_t go_back_x_packets; // Used to start the playback from a certain point in the past
-} playback_hb_tlm_payload_t;
 
 /*
 *  Command for playing back the heartbeat telemetry logs
@@ -29,4 +24,4 @@ typedef struct PlaybackHBTLMPayload {
 *  - If go_back_x_packets is 0, it will begin at the most recently logged packet, otherwise it will traverse back go_back_x_packets packets first before collecting packets
 *  - Returns 0 on success, 1 on missing tlm directory, 2 on f_info.bin read error, 5 on reached end of logs
 */
-int hb_tlm_playback(playback_hb_tlm_payload_t playback_payload);
+int hb_tlm_playback(playback_hb_tlm_payload_t* playback_payload);

--- a/main/utilities/include/hb_tlm_log.h
+++ b/main/utilities/include/hb_tlm_log.h
@@ -1,0 +1,81 @@
+#pragma once
+#include <stdint.h>
+//#include "telemetry.h"
+
+typedef struct __attribute__((__packed__)) {
+    uint8_t state;
+    uint32_t uptime;
+    uint8_t hour;
+    uint8_t minute;
+    uint8_t second;
+    uint8_t month;
+    uint8_t date;
+    uint8_t year;
+    float rtcTemp; 
+    uint16_t ina0_shunt;
+    uint16_t ina0_vbus;
+    uint16_t ina0_power;
+    uint16_t ina0_current;
+    uint16_t ina1_shunt; 
+    uint16_t ina1_vbus;
+    uint16_t ina1_power;
+    uint16_t ina1_current;
+    uint16_t ina2_shunt; 
+    uint16_t ina2_vbus;
+    uint16_t ina2_power;
+    uint16_t ina2_current;
+    uint16_t ina3_shunt; 
+    uint16_t ina3_vbus;
+    uint16_t ina3_power;
+    uint16_t ina3_current;
+    uint16_t ina4_shunt; 
+    uint16_t ina4_vbus;
+    uint16_t ina4_power;
+    uint16_t ina4_current;
+    uint16_t ina5_shunt; 
+    uint16_t ina5_vbus;
+    uint16_t ina5_power;
+    uint16_t ina5_current;
+    float max17048Voltage;
+    float max17048Percentage;
+    int16_t mag_x;
+    int16_t mag_y;
+    int16_t mag_z;
+    int16_t mag_temp;
+    uint8_t vega_ant_status;
+
+    int16_t rfm_state; 
+    int16_t sx_state; 
+    uint8_t which_radio; // 1 for RFM
+} heartbeat_telemetry2_t;
+
+
+
+// Contents of f_info.bin file which keeps track of information about the logging size and files for the heartbeat tlm in the /tlm directory
+typedef struct HBTlmFilesInfo {
+    uint16_t file_index; // Keeps track of the most recent index of tlm file (not necessarily how many files are in the current directory)
+    uint16_t oldest_file_index; // Index or name of the oldest tlm log in the directory
+    uint16_t directory_size; // Keeps track of the total size that these files are taking up
+} hb_tlm_file_size_info_t;
+
+/* 
+*  Keep a /tlm directory where:
+*  - /tlm/file_counter.bin file contains the index of the next file to be created - 2 bytes
+*  - /tlm/0.bin, /tlm/1.bin, ... /tlm/65535 files contain the telemetry data, most recent of which is the number.bin contained in the file_counter.txt file
+*/
+void log_heartbeat_tlm(heartbeat_telemetry2_t payload);
+
+// Command payload for the playback heartbeat telemetry command
+typedef struct PlaybackHBTLMPayload {
+    uint16_t number_of_packets;
+    uint16_t every_x_packet; // Used to adjust for less resolution but cover more time
+    uint16_t go_back_x_packets; // Used to start the playback from a certain point in the past
+} playback_hb_tlm_payload_t;
+
+/*
+*  Command for playing back the heartbeat telemetry logs
+*  - Goes through each file, aquiring packets until number_of_packets at intervals of every_x_packet
+*  - If go_back_x_packets is 0, it will begin at the most recently logged packet, otherwise it will traverse back go_back_x_packets packets first before collecting packets
+*  - Returns 0 on success, 1 on missing tlm directory, 2 on f_info.bin read error
+*/
+int hb_tlm_playback(playback_hb_tlm_payload_t playback_payload);

--- a/main/utilities/src/hb_tlm_log.c
+++ b/main/utilities/src/hb_tlm_log.c
@@ -3,6 +3,7 @@
 #include "filesystem.h"
 #include <stdbool.h>
 #include <stdio.h>
+#include <string.h>
 
 // Size (bytes) that a heartbeat telemetry file can be until a new one should be used
 // If writing a new telemetry entry causes the file to go over this amount, a new file is made
@@ -12,7 +13,7 @@
 // Once this limit is reached, the oldest log will be deleted before a new one is created
 #define MAX_HB_TLM_TOTAL_SIZE 10000 //1250000 // 10 MBit to bytes
 
-void log_heartbeat_tlm(heartbeat_telemetry2_t payload) {
+void log_heartbeat_tlm(heartbeat_telemetry_t payload) {
 
     // See if tlm directory exists
     if (!dir_exists("/tlm")) {
@@ -26,9 +27,6 @@ void log_heartbeat_tlm(heartbeat_telemetry2_t payload) {
             sizeof(hb_tlm_file_size_info_t) // directory only has this file in it, so start the directory size at this
         };
         write_file("/tlm/f_info.bin", (char*)&f_data, sizeof(hb_tlm_file_size_info_t), false); // create and write to the file info file
-
-        logln_info("TLM dir:");
-        list_dir("/tlm");
     }
 
     // Read the file info
@@ -38,19 +36,16 @@ void log_heartbeat_tlm(heartbeat_telemetry2_t payload) {
         logln_error("Error reading f_info.bin");
         return;
     }
-
-    logln_info("Heartbeat tlm file index: %d", file_info_buf.file_index);
     
     // Write to this indexed file
     char filename[20];
     snprintf(filename, sizeof(filename), "/tlm/%d.bin", file_info_buf.file_index);
-    logln_info("Writing to file: %s", filename);
     write_file(filename, (char*)&payload, sizeof(payload), true); // append - this will eaither make the file if it does not exist or append to it if it does
 
     // Check file size to see if it is time to make a new file. If writing another hb to the file makes it go over the limit, 
     FILINFO file_info;
     stat(filename, &file_info);
-    if (file_info.fsize + sizeof(heartbeat_telemetry2_t) > MAX_HB_TLM_FILE_SIZE) {
+    if (file_info.fsize + sizeof(heartbeat_telemetry_t) > MAX_HB_TLM_FILE_SIZE) {
         // Increase f_count.bin by 1 for next time
         file_info_buf.file_index += 1;
         file_info_buf.directory_size += MAX_HB_TLM_FILE_SIZE; // Only increase once the file is full, it doesn't get checked until the file is full anyway
@@ -61,26 +56,21 @@ void log_heartbeat_tlm(heartbeat_telemetry2_t payload) {
             char oldest_filename[20];
             snprintf(oldest_filename, sizeof(oldest_filename), "/tlm/%d.bin", file_info_buf.oldest_file_index);
             delete_file(oldest_filename);
-            logln_info("Deleted oldest file: %s", oldest_filename);
             file_info_buf.oldest_file_index += 1;
 
             file_info_buf.directory_size -= MAX_HB_TLM_FILE_SIZE; // Remove the size of that full file, this value will end up oscillating once the directory is full
         }
     }
 
-    logln_info("Tlm file info: %d, %d, %d", file_info_buf.file_index, file_info_buf.oldest_file_index, file_info_buf.directory_size);
-
     // Write the new file info information in case anything changed
     write_file("/tlm/f_info.bin", (char*)&file_info_buf, sizeof(hb_tlm_file_size_info_t), false);
-
-    logln_info("\nTLM DIR:");
-    list_dir("/tlm");
     
 }
 
 int hb_tlm_playback(playback_hb_tlm_payload_t playback_payload) {
     
-    logln_info("PLAYBACK");
+    logln_info("PLAYBACK: every x packer: %d,  go back x packets: %d, number of packets: %d", 
+        playback_payload.every_x_packet, playback_payload.go_back_x_packets, playback_payload.number_of_packets);
 
     // Make sure tlm exists
     if (!dir_exists("/tlm")) {
@@ -101,58 +91,64 @@ int hb_tlm_playback(playback_hb_tlm_payload_t playback_payload) {
     char current_log_filename[20];
     snprintf(current_log_filename, sizeof(current_log_filename), "/tlm/%d.bin", file_index);
 
-    int packet_counter = 0; // keep track of how many packets have been transmitted until file_info_buf.number_of_packets
-    while (packet_counter < playback_payload.number_of_packets) {
+    // Keep track of how many packets have been iterated over
+    int packet_counter = 0;
+
+    // Keep track of how many packets have been transmitted until file_info_buf.number_of_packets
+    // can differ from packet_counter depending on every_x_packet
+    int packet_sent_counter = 0;
+
+    while (packet_sent_counter < playback_payload.number_of_packets) {
 
         // For now, read the entire file into memory, this may need to be changed, or maybe just the MAX_HB_TLM_FILE_SIZE should be changed
         char tlm_buf[MAX_HB_TLM_FILE_SIZE];
         bytes_read = read_file(current_log_filename, tlm_buf, MAX_HB_TLM_FILE_SIZE);
-        bool partial_read = false;
-        if (bytes_read != MAX_HB_TLM_FILE_SIZE) {
-            if (bytes_read > 0) {
-                // End of logs - only read a partial file
-                partial_read = true;
-            } else {
-                logln_error("Playback - read error occured");
-                return 3;
-            }
-        }
-
-        // Overwrite with the next file index for the next loop if needed
-        file_index -= 1;
-        if (file_index < file_info_buf.oldest_file_index) {
-            logln_error("Playback - reached end of logs");
-            return 4;
-        }
-        snprintf(current_log_filename, sizeof(current_log_filename), "/tlm/%d.bin", file_info_buf.file_index);
+        if (bytes_read <= 0) {
+            logln_error("Playback - read error occured: %d", bytes_read);
+            return 3;
+       }
 
         // Loop through this specific file
         // file_index is where the next heartbeat packet starts in the file buffer - going backwards
-        int packet_index = bytes_read - sizeof(heartbeat_telemetry2_t);
-        heartbeat_telemetry2_t hb_tlm_buf;
+        int packet_index = bytes_read - sizeof(heartbeat_telemetry_t);
+        heartbeat_telemetry_t hb_tlm_buf;
         while (packet_index >= 0) {
             // Check if this packet should be sent
             if (packet_counter % playback_payload.every_x_packet != 0) {
+                packet_index -= sizeof(heartbeat_telemetry_t); // Move index
+                packet_counter++; // Increase packet iteration counter
                 continue;
             }
 
             // If we want to send this one, read it into memory and send it
-            memcpy(&hb_tlm_buf, packet_index, sizeof(heartbeat_telemetry2_t));
+            memcpy(&hb_tlm_buf, &tlm_buf[packet_index], sizeof(heartbeat_telemetry_t));
 
             logln_info("Sending playback packet #%d, from file %s, with index into file of %d", packet_counter, current_log_filename, packet_index);
 
             // Send the packet
-            send_telemetry(7/*HEARTBEAT_PLAYBACK*/, (char*)&hb_tlm_buf, sizeof(heartbeat_telemetry2_t));
-            packet_counter += 1;
+            send_telemetry(HEARTBEAT_PLAYBACK, (char*)&hb_tlm_buf, sizeof(heartbeat_telemetry_t));
+            packet_sent_counter += 1;
+            packet_counter++;
 
             // Check if we have reached the end
-            if (packet_counter >= playback_payload.number_of_packets) {
+            if (packet_sent_counter >= playback_payload.number_of_packets) {
                 break;
             }
 
             // Move to the next packet
-            packet_index -= sizeof(heartbeat_telemetry2_t);
+            packet_index -= sizeof(heartbeat_telemetry_t);
         }
+
+        // Finished reading this file, see if it's the oldest file, if it is and we have more to read, return error - reached end of logs
+        if (file_index == file_info_buf.oldest_file_index && packet_sent_counter < playback_payload.number_of_packets) {
+            logln_error("Playback - reached end of logs");
+            return 5;
+        }
+
+        // Overwrite with the next file index for the next loop if needed
+        file_index -= 1;
+        snprintf(current_log_filename, sizeof(current_log_filename), "/tlm/%d.bin", file_index);
+
     }
 
     return 0;

--- a/main/utilities/src/hb_tlm_log.c
+++ b/main/utilities/src/hb_tlm_log.c
@@ -67,10 +67,10 @@ void log_heartbeat_tlm(heartbeat_telemetry_t payload) {
     
 }
 
-int hb_tlm_playback(playback_hb_tlm_payload_t playback_payload) {
+int hb_tlm_playback(playback_hb_tlm_payload_t* playback_payload) {
     
     logln_info("PLAYBACK: every x packer: %d,  go back x packets: %d, number of packets: %d", 
-        playback_payload.every_x_packet, playback_payload.go_back_x_packets, playback_payload.number_of_packets);
+        playback_payload->every_x_packet, playback_payload->go_back_x_packets, playback_payload->number_of_packets);
 
     // Make sure tlm exists
     if (!dir_exists("/tlm")) {
@@ -98,7 +98,7 @@ int hb_tlm_playback(playback_hb_tlm_payload_t playback_payload) {
     // can differ from packet_counter depending on every_x_packet
     int packet_sent_counter = 0;
 
-    while (packet_sent_counter < playback_payload.number_of_packets) {
+    while (packet_sent_counter < playback_payload->number_of_packets) {
 
         // For now, read the entire file into memory, this may need to be changed, or maybe just the MAX_HB_TLM_FILE_SIZE should be changed
         char tlm_buf[MAX_HB_TLM_FILE_SIZE];
@@ -114,7 +114,7 @@ int hb_tlm_playback(playback_hb_tlm_payload_t playback_payload) {
         heartbeat_telemetry_t hb_tlm_buf;
         while (packet_index >= 0) {
             // Check if this packet should be sent
-            if (packet_counter % playback_payload.every_x_packet != 0) {
+            if (packet_counter % playback_payload->every_x_packet != 0) {
                 packet_index -= sizeof(heartbeat_telemetry_t); // Move index
                 packet_counter++; // Increase packet iteration counter
                 continue;
@@ -131,7 +131,7 @@ int hb_tlm_playback(playback_hb_tlm_payload_t playback_payload) {
             packet_counter++;
 
             // Check if we have reached the end
-            if (packet_sent_counter >= playback_payload.number_of_packets) {
+            if (packet_sent_counter >= playback_payload->number_of_packets) {
                 break;
             }
 
@@ -140,7 +140,7 @@ int hb_tlm_playback(playback_hb_tlm_payload_t playback_payload) {
         }
 
         // Finished reading this file, see if it's the oldest file, if it is and we have more to read, return error - reached end of logs
-        if (file_index == file_info_buf.oldest_file_index && packet_sent_counter < playback_payload.number_of_packets) {
+        if (file_index == file_info_buf.oldest_file_index && packet_sent_counter < playback_payload->number_of_packets) {
             logln_error("Playback - reached end of logs");
             return 5;
         }

--- a/main/utilities/src/hb_tlm_log.c
+++ b/main/utilities/src/hb_tlm_log.c
@@ -1,0 +1,160 @@
+#include "hb_tlm_log.h"
+#include "log.h"
+#include "filesystem.h"
+#include <stdbool.h>
+#include <stdio.h>
+
+// Size (bytes) that a heartbeat telemetry file can be until a new one should be used
+// If writing a new telemetry entry causes the file to go over this amount, a new file is made
+#define MAX_HB_TLM_FILE_SIZE 2000 // About an 15 minute of tlm, small enough to read into memory for playback
+
+// Tlm files of the size specified by MAX_HB_TLM_FILE_SIZE will continue to be created until creating a new file of said size will surpase or equal this limit
+// Once this limit is reached, the oldest log will be deleted before a new one is created
+#define MAX_HB_TLM_TOTAL_SIZE 10000 //1250000 // 10 MBit to bytes
+
+void log_heartbeat_tlm(heartbeat_telemetry2_t payload) {
+
+    // See if tlm directory exists
+    if (!dir_exists("/tlm")) {
+        make_dir("/tlm");
+
+        // Create the file info file as well
+
+        hb_tlm_file_size_info_t f_data = {
+            0, // Start at index 0
+            0, // Oldest file has index 0
+            sizeof(hb_tlm_file_size_info_t) // directory only has this file in it, so start the directory size at this
+        };
+        write_file("/tlm/f_info.bin", (char*)&f_data, sizeof(hb_tlm_file_size_info_t), false); // create and write to the file info file
+
+        logln_info("TLM dir:");
+        list_dir("/tlm");
+    }
+
+    // Read the file info
+    hb_tlm_file_size_info_t file_info_buf;
+    int bytes_read = read_file("/tlm/f_info.bin", (char*)&file_info_buf, sizeof(hb_tlm_file_size_info_t));
+    if (bytes_read != sizeof(hb_tlm_file_size_info_t)) {
+        logln_error("Error reading f_info.bin");
+        return;
+    }
+
+    logln_info("Heartbeat tlm file index: %d", file_info_buf.file_index);
+    
+    // Write to this indexed file
+    char filename[20];
+    snprintf(filename, sizeof(filename), "/tlm/%d.bin", file_info_buf.file_index);
+    logln_info("Writing to file: %s", filename);
+    write_file(filename, (char*)&payload, sizeof(payload), true); // append - this will eaither make the file if it does not exist or append to it if it does
+
+    // Check file size to see if it is time to make a new file. If writing another hb to the file makes it go over the limit, 
+    FILINFO file_info;
+    stat(filename, &file_info);
+    if (file_info.fsize + sizeof(heartbeat_telemetry2_t) > MAX_HB_TLM_FILE_SIZE) {
+        // Increase f_count.bin by 1 for next time
+        file_info_buf.file_index += 1;
+        file_info_buf.directory_size += MAX_HB_TLM_FILE_SIZE; // Only increase once the file is full, it doesn't get checked until the file is full anyway
+
+        // See if there is enough space for the new file, otherwise delete the oldest file
+        if (file_info_buf.directory_size + MAX_HB_TLM_FILE_SIZE > MAX_HB_TLM_TOTAL_SIZE) {
+            // Delete the oldest file in the directory an increase the oldest file counter by 1
+            char oldest_filename[20];
+            snprintf(oldest_filename, sizeof(oldest_filename), "/tlm/%d.bin", file_info_buf.oldest_file_index);
+            delete_file(oldest_filename);
+            logln_info("Deleted oldest file: %s", oldest_filename);
+            file_info_buf.oldest_file_index += 1;
+
+            file_info_buf.directory_size -= MAX_HB_TLM_FILE_SIZE; // Remove the size of that full file, this value will end up oscillating once the directory is full
+        }
+    }
+
+    logln_info("Tlm file info: %d, %d, %d", file_info_buf.file_index, file_info_buf.oldest_file_index, file_info_buf.directory_size);
+
+    // Write the new file info information in case anything changed
+    write_file("/tlm/f_info.bin", (char*)&file_info_buf, sizeof(hb_tlm_file_size_info_t), false);
+
+    logln_info("\nTLM DIR:");
+    list_dir("/tlm");
+    
+}
+
+int hb_tlm_playback(playback_hb_tlm_payload_t playback_payload) {
+    
+    logln_info("PLAYBACK");
+
+    // Make sure tlm exists
+    if (!dir_exists("/tlm")) {
+        logln_error("No tlm directory found on playback");
+        return 1;
+    }
+
+    // Read the file info
+    hb_tlm_file_size_info_t file_info_buf;
+    int bytes_read = read_file("/tlm/f_info.bin", (char*)&file_info_buf, sizeof(hb_tlm_file_size_info_t));
+    if (bytes_read != sizeof(hb_tlm_file_size_info_t)) {
+        logln_error("Error reading f_info.bin");
+        return 2;
+    }
+
+    // Start at the most recent file
+    uint16_t file_index = file_info_buf.file_index;
+    char current_log_filename[20];
+    snprintf(current_log_filename, sizeof(current_log_filename), "/tlm/%d.bin", file_index);
+
+    int packet_counter = 0; // keep track of how many packets have been transmitted until file_info_buf.number_of_packets
+    while (packet_counter < playback_payload.number_of_packets) {
+
+        // For now, read the entire file into memory, this may need to be changed, or maybe just the MAX_HB_TLM_FILE_SIZE should be changed
+        char tlm_buf[MAX_HB_TLM_FILE_SIZE];
+        bytes_read = read_file(current_log_filename, tlm_buf, MAX_HB_TLM_FILE_SIZE);
+        bool partial_read = false;
+        if (bytes_read != MAX_HB_TLM_FILE_SIZE) {
+            if (bytes_read > 0) {
+                // End of logs - only read a partial file
+                partial_read = true;
+            } else {
+                logln_error("Playback - read error occured");
+                return 3;
+            }
+        }
+
+        // Overwrite with the next file index for the next loop if needed
+        file_index -= 1;
+        if (file_index < file_info_buf.oldest_file_index) {
+            logln_error("Playback - reached end of logs");
+            return 4;
+        }
+        snprintf(current_log_filename, sizeof(current_log_filename), "/tlm/%d.bin", file_info_buf.file_index);
+
+        // Loop through this specific file
+        // file_index is where the next heartbeat packet starts in the file buffer - going backwards
+        int packet_index = bytes_read - sizeof(heartbeat_telemetry2_t);
+        heartbeat_telemetry2_t hb_tlm_buf;
+        while (packet_index >= 0) {
+            // Check if this packet should be sent
+            if (packet_counter % playback_payload.every_x_packet != 0) {
+                continue;
+            }
+
+            // If we want to send this one, read it into memory and send it
+            memcpy(&hb_tlm_buf, packet_index, sizeof(heartbeat_telemetry2_t));
+
+            logln_info("Sending playback packet #%d, from file %s, with index into file of %d", packet_counter, current_log_filename, packet_index);
+
+            // Send the packet
+            send_telemetry(7/*HEARTBEAT_PLAYBACK*/, (char*)&hb_tlm_buf, sizeof(heartbeat_telemetry2_t));
+            packet_counter += 1;
+
+            // Check if we have reached the end
+            if (packet_counter >= playback_payload.number_of_packets) {
+                break;
+            }
+
+            // Move to the next packet
+            packet_index -= sizeof(heartbeat_telemetry2_t);
+        }
+    }
+
+    return 0;
+
+}

--- a/main/utilities/src/log.c
+++ b/main/utilities/src/log.c
@@ -45,7 +45,8 @@ void _log(const char *str, ...) {
 
 #ifdef SIMULATOR
     // write to stdout
-    write(1, packet->str, strsize);
+    //write(1, packet->str, strsize);
+    send_telemetry(LOG, (char*)packet, sizeof(log_telemetry_t) + strsize + 1);
 #else
     // send to telemetry task
     send_telemetry(LOG, (char*)packet, sizeof(log_telemetry_t) + strsize + 1);


### PR DESCRIPTION
Logs each heartbeat packet up to a certain size, separates log files by a certain size in hb_tlm_log.h, logs will be automatically rotated (as in old log files will be deleted as needed)
Also added playback packets command, which allows packets to be replayed by the ground station.

Added documentation for COSMOS integration with the simulator.

Tested and working with this GSE commit - https://github.com/ASU-SDSL/coconut-gse/commit/813367634425b9a8636911d54288d39bed674f9a