### PR TITLE
Error logging and ack packets

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -71,5 +71,34 @@
                 }
             ]
         },
+        {
+            "name": "Coconut Log Unit Test Debug",
+            "type": "cppdbg",
+            "request": "launch",
+            "preLaunchTask": "buildsimulator",
+            "program": "${workspaceRoot}/build/UnitTest/bin/log_test_utest",
+            // "args": [ "1", "<", "${workspaceFolder}/packet.bin"],
+            "stopAtEntry": false,
+            "cwd": "${workspaceRoot}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Disable SIGALRM handler in gdb",
+                    "text": "handle SIGALRM pass noprint"
+                }
+            ]
+        },
     ]
 }

--- a/docs/DOCS.md
+++ b/docs/DOCS.md
@@ -240,6 +240,6 @@ Tasks can also be removed, their interval altered, and more. See the `steve.h` h
 
 ## Interacting with the Filesystem
 
-See the `main/tasks/filesystem/filesystem.c` for more info on the API functions used to interact with the file system. These functions can be called by any task. There are already plenty of files that interact with the filesystem in the codebase, with `main/utilities/user_auth.c` being one of the better examples.
+See the `main/tasks/filesystem/filesystem.c` for more info on the API functions used to interact with the file system. These functions can be called by any task using the `filesystem.h` header file. There are already plenty of files that interact with the filesystem in the codebase, with `main/utilities/user_auth.c` being one of the better examples.
 
 The filesystem interacts with the MRAM flash memory through the `main/drivers/diskio.c` device driver. This driver contains all the SPI read/write logic and should work with other SPI flash chips with some minor modifications (mainly check maximum storage size). The simulator also supports the filesystem through the use of a seperate RAM-disk device driver in `main/simulator/drivers/diskio.c`. 

--- a/main/.vscode/settings.json
+++ b/main/.vscode/settings.json
@@ -2,6 +2,9 @@
     "files.associations": {
         "rtc_ds3231.h": "c",
         "mag_lis3mdltr.h": "c",
-        "gpio.h": "c"
+        "gpio.h": "c",
+        "sstream": "c",
+        "stdbool.h": "c",
+        "filesystem.h": "c"
     }
 }

--- a/main/tasks/command/command.c
+++ b/main/tasks/command/command.c
@@ -160,7 +160,7 @@ void parse_command_packet(spacepacket_header_t header, uint8_t* payload_buf, uin
 
     send_telemetry(ACK, (char*) ack, ack_size); // Send ack
 
-    pvPortFree(ack);
+    vPortFree(ack);
 }
 
 void command_task(void* unused_arg) {

--- a/main/tasks/command/command.c
+++ b/main/tasks/command/command.c
@@ -43,6 +43,13 @@ void receive_command_bytes(uint8_t* packet, size_t packet_size) {
 
 void parse_command_packet(spacepacket_header_t header, uint8_t* payload_buf, uint32_t payload_size) {
     logln_info("Received command with APID: %hu", header.apid);
+
+    // Used for the ack struct
+    uint8_t command_status = 1; // 1 for success/true, 0 for failure/false
+    // Data may or may not be returned, this data should be allocated and freed if needed depending on the packet
+    uint8_t *return_data = NULL;
+    int return_data_len = 0;
+
     switch (header.apid) {
         case UPLOAD_USER_DATA:
             if (payload_size < sizeof(upload_user_data_t)) break;
@@ -130,11 +137,28 @@ void parse_command_packet(spacepacket_header_t header, uint8_t* payload_buf, uin
         case PLAYBACK_HEARTBEAT_PACKETS:
             if (payload_size < sizeof(playback_hb_tlm_payload_t)) break; // Should probably return an error to the ground
             playback_hb_tlm_payload_t* playback_hb_payload = (playback_hb_tlm_payload_t*)payload_buf;
-            hb_tlm_playback(playback_hb_payload);
+            int status = hb_tlm_playback(playback_hb_payload);
+            if (status != 0) command_status = 0;
             break;
+        case FSW_ACK:
+            break; // This will just send the ack
         default:
             logln_error("Received command with unknown APID: %hu", header.apid);
     }
+
+    // Send ack
+
+    int ack_size = sizeof(ack_telemetry_t) + return_data_len;
+    ack_telemetry_t *ack = pvPortMalloc(ack_size);
+    ack->command_status = command_status;
+    ack->data = return_data;
+
+    // Get last error
+    char last_error[MAX_ERROR_LOG_STR_SIZE];
+    get_most_recent_logged_error(last_error);
+    strncpy(ack->last_logged_error, last_error, sizeof(ack->last_logged_error)); // Copy only first 24 chars (or however many the ack struct says)
+
+    send_telemetry(ACK, (char*) ack, ack_size); // Send ack
 }
 
 void command_task(void* unused_arg) {

--- a/main/tasks/command/command.c
+++ b/main/tasks/command/command.c
@@ -155,10 +155,12 @@ void parse_command_packet(spacepacket_header_t header, uint8_t* payload_buf, uin
 
     // Get last error
     char last_error[MAX_ERROR_LOG_STR_SIZE];
-    get_most_recent_logged_error(last_error);
+    get_most_recent_logged_error(last_error, MAX_ERROR_LOG_STR_SIZE);
     strncpy(ack->last_logged_error, last_error, sizeof(ack->last_logged_error)); // Copy only first 24 chars (or however many the ack struct says)
 
     send_telemetry(ACK, (char*) ack, ack_size); // Send ack
+
+    pvPortFree(ack);
 }
 
 void command_task(void* unused_arg) {

--- a/main/tasks/command/command.h
+++ b/main/tasks/command/command.h
@@ -26,6 +26,7 @@ typedef enum command_apid {
     DELETE_USER = 13,
     MCU_POWER_CYCLE = 14,
     PLAYBACK_HEARTBEAT_PACKETS = 15,
+    FSW_ACK = 16,
 } command_apid_t;
 
 typedef struct __attribute__((__packed__)) {

--- a/main/tasks/filesystem/filesystem.c
+++ b/main/tasks/filesystem/filesystem.c
@@ -444,7 +444,9 @@ void filesystem_task(void* unused_arg) {
     filesystem_queue_operations_t received_operation;
     while(1) {
         // wait until an operation is in queue
+        logln_info("Wait for filesystem queue");
         xQueueReceive(filesystem_queue, &received_operation, EMPTY_QUEUE_WAIT_TIME);
+        logln_info("HERE DONE Wait for filesystem queue");
         // parse and execute operation
         switch (received_operation.operation_type) {
             case MAKE_FILESYSTEM: {

--- a/main/tasks/filesystem/filesystem.c
+++ b/main/tasks/filesystem/filesystem.c
@@ -256,7 +256,7 @@ int32_t _fwrite(const char* file_name, const uint8_t *data, size_t size, bool ap
     FRESULT fr;
     FIL fil;
 
-    logln_info("Writing to file: %s\n", file_name);
+    logln_info("Writing to file: %s", file_name);
 
     int file_open_flags = FA_WRITE | FA_CREATE_ALWAYS;
     if (append_flag) { file_open_flags = FA_OPEN_APPEND | FA_WRITE; }
@@ -444,9 +444,7 @@ void filesystem_task(void* unused_arg) {
     filesystem_queue_operations_t received_operation;
     while(1) {
         // wait until an operation is in queue
-        logln_info("Wait for filesystem queue");
         xQueueReceive(filesystem_queue, &received_operation, EMPTY_QUEUE_WAIT_TIME);
-        logln_info("HERE DONE Wait for filesystem queue");
         // parse and execute operation
         switch (received_operation.operation_type) {
             case MAKE_FILESYSTEM: {

--- a/main/tasks/filesystem/filesystem.h
+++ b/main/tasks/filesystem/filesystem.h
@@ -23,6 +23,10 @@
 #define MAX_PATH_SIZE 0xFF
 #define MAX_WRITE_CONTENTS_SIZE 0x100
 
+/* File storage allocation */
+#define ERROR_LOGS_FS_ALLOCATION 0x300U // Max bytes for error logs. Should be a multiple of MAX_ERROR_LOG_STR_SIZE (see log.h)
+#define HEARTBEAT_TLM_FS_ALLOCATION 10000 //1250000 // 10 MBit to bytes - should be a multiple of MAX_HB_TLM_FILE_SIZE (see hb_tlm_log.c)
+
 /* Types and Globals */
 typedef enum fs_operation_type {
     MAKE_FILESYSTEM,

--- a/main/tasks/main/main.c
+++ b/main/tasks/main/main.c
@@ -50,7 +50,7 @@ int main() {
 
     BaseType_t command_task_status = xTaskCreate(command_task,
                                         "COMMAND",
-                                        512,
+                                        1024,
                                         NULL,
                                         1,
                                         NULL);

--- a/main/tasks/steve/jobs/heartbeat_job.c
+++ b/main/tasks/steve/jobs/heartbeat_job.c
@@ -165,5 +165,6 @@ void heartbeat_telemetry_job(void* unused) {
 
     iteration_counter += 1;
 
+    logln_error("TEST ERROR");
     logln_info("Heartbeat %ld - uptime: %d", iteration_counter, (uint32_t)get_uptime());
 }

--- a/main/tasks/steve/jobs/heartbeat_job.c
+++ b/main/tasks/steve/jobs/heartbeat_job.c
@@ -165,6 +165,5 @@ void heartbeat_telemetry_job(void* unused) {
 
     iteration_counter += 1;
 
-    logln_error("TEST ERROR");
     logln_info("Heartbeat %ld - uptime: %d", iteration_counter, (uint32_t)get_uptime());
 }

--- a/main/tasks/steve/jobs/heartbeat_job.h
+++ b/main/tasks/steve/jobs/heartbeat_job.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #define HEARTBEAT_JOB_NAME "heartbeat_telemetry"
-#define HEARTBEAT_TELEMETRY_DEFAULT_INTERVAL 10
+#define HEARTBEAT_TELEMETRY_DEFAULT_INTERVAL 5
 
 uint32_t iteration_counter;
 

--- a/main/tasks/telemetry/telemetry.h
+++ b/main/tasks/telemetry/telemetry.h
@@ -19,6 +19,7 @@ typedef enum {
     DOWNLINK_GROUNDNODE_DATA = 2, 
     DOWNLINK_TELEMETRY_DATA = 3,
     HEARTBEAT_PLAYBACK = 4,
+    ACK = 5,
 } telemetry_apid_t;
 
 typedef struct __attribute__((__packed__)) {
@@ -72,6 +73,13 @@ typedef struct __attribute__((__packed__)) {
     int16_t sx_state; 
     uint8_t which_radio; // 1 for RFM
 } heartbeat_telemetry_t;
+
+// Telemetry response to any commands sent to the satellite
+typedef struct __attribute__((__packed__)) {
+    uint8_t command_status; // 1 for success/true, 0 for failure/false
+    char last_logged_error[24];
+    uint8_t *data; // Any extra data that might be returned by a command
+} ack_telemetry_t;
 
 /* USER FUNCTIONS */
 void send_telemetry(telemetry_apid_t apid, const char* payload_buffer, size_t payload_size);

--- a/main/test/unit/CMakeLists.txt
+++ b/main/test/unit/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(cmock libunity.a)
 
 # add unit test subdirectories here
 add_subdirectory(./steve steve)
+add_subdirectory(./log log)
 
 # add_custom_target(coverage
 #     COMMAND ${CMAKE_COMMAND} -P ${CMAKE_SOURCE_DIR}/tools/cmock/coverage.cmake

--- a/main/test/unit/log/CMakeLists.txt
+++ b/main/test/unit/log/CMakeLists.txt
@@ -1,0 +1,87 @@
+project ("steve unit test")
+cmake_minimum_required (VERSION 3.13)
+
+set(project_name "log_test")
+
+# =====================  Create your mock here  ========================
+
+# set(mock_name "${project_name}_mock")
+
+# list(APPEND mock_list
+    # ${MAIN_DIRECTORY}/tasks/steve/steve.h
+# )
+        
+# list(APPEND mock_include_list
+    # ${FREERTOS_CFG_DIRECTORY}/
+    # ${FREERTOS_SRC_DIRECTORY}/include
+    # ${CMAKE_SOURCE_DIR}/freertos/portable/ThirdParty/GCC/Posix
+    # ${CMAKE_SOURCE_DIR}/freertos/portable/ThirdParty/GCC/Posix/utils
+
+    # ${MAIN_DIRECTORY}/tasks/steve
+    # ${MAIN_DIRECTORY}/tasks/steve/jobs
+    # ${MAIN_DIRECTORY}/tasks/telemetry
+    # ${MAIN_DIRECTORY}/tasks/gse
+    # ${MAIN_DIRECTORY}/tasks/command
+    # ${MAIN_DIRECTORY}/utilities/include
+    # ${MAIN_DIRECTORY}/drivers/include
+
+    # ${MAIN_DIRECTORY}/simulator/pico-sdk
+    # ${MAIN_DIRECTORY}/simulator/tasks/radio
+# )
+
+# list(APPEND mock_define_list
+#     portHAS_STACK_OVERFLOW_CHECKING=1
+# )
+
+
+# create_mock_list(${mock_name}
+#     "${mock_list}"
+#     ${CMAKE_SOURCE_DIR}/main/test/unit/project.yml
+#     "${mock_include_list}"
+#     "${mock_define_list}"
+# )
+
+# Code/library under test
+
+list(APPEND real_source_files
+    ${SOURCES}
+)
+
+list(APPEND real_include_directories
+    ${FREERTOS_INCLUDE_FILES}
+    ${INTERNAL_INCLUDE_DIRS}
+)
+# Unit test binary
+
+list(APPEND test_include_directories
+    ${FREERTOS_INCLUDE_FILES}
+    ${INTERNAL_INCLUDE_DIRS}
+)
+
+set(real_name "${project_name}_real")
+
+create_real_library(${real_name}
+    "${real_source_files}"
+    "${real_include_directories}"
+    "${mock_name}"
+)
+
+target_link_libraries(${real_name} LINK_PUBLIC
+    ${LINK_LIBS}
+)
+
+list(APPEND utest_link_list
+    # -l${mock_name}
+    ${real_name}
+    -lpthread
+    ${LINK_LIBS}
+)
+
+set(utest_name ${project_name}_utest)
+set(utest_source ${project_name}_unittest.c)
+create_test(${utest_name}
+    ${utest_source}
+    "${utest_link_list}"
+    "${utest_dep_list}"
+    "${test_include_directories}"
+)

--- a/main/test/unit/log/log_test_unittest.c
+++ b/main/test/unit/log/log_test_unittest.c
@@ -1,12 +1,53 @@
 #include "FreeRTOS.h"
+#include <string.h>
 
 #include "unity.h"
 
 #include "filesystem.h"
 #include "log.h"
 
-// Log a single error and check if it is retrieved correctly
+// Used on all tests to begin the filesystem task and to start the test task defined by each test (function pointer task_func_ptr)
+typedef void (*TaskFunction_t)(void *);
+static void test_log_rtos_scheduler_begin(TaskFunction_t task_func_ptr) {
+
+    TaskHandle_t xFilesystemHandler = NULL; // Used for deleting after the test
+
+    BaseType_t filesystem_task_status = xTaskCreate(filesystem_task,
+                                        "FILESYSTEM",
+                                        1024,
+                                        NULL,
+                                        1,
+                                        &xFilesystemHandler);
+
+    BaseType_t testing_task_status = xTaskCreate(task_func_ptr,
+                                        "TEST",
+                                        1024,
+                                        xFilesystemHandler, 
+                                        1,
+                                        NULL); 
+
+    // Start Filesystem scheduler and test task
+    vTaskStartScheduler();
+
+}
+
+// Required at the end of each test task to exit correctly for the next test
+static void end_test_task(TaskHandle_t xFilesystemHandler) {
+    vTaskEndScheduler();
+    vTaskDelete(xFilesystemHandler); // Delete filesystem task
+    vTaskDelete(NULL); // Delete this current task
+}
+
+
+/****** Beginning of tests *******/
+
+
+/* 
+*  Log a single error and check if it is retrieved correctly
+*/
 static void test_log_single_error_testtask( void *pvParameters ) {
+
+    TaskHandle_t xFilesystemHandler = (TaskHandle_t)pvParameters;
 
     TEST_MESSAGE("Starting test test_log_single_error_testtask");
 
@@ -18,38 +59,26 @@ static void test_log_single_error_testtask( void *pvParameters ) {
     // Compare strings
     TEST_ASSERT_EQUAL_STRING("Test error", error_str);
 
-    // Kill scheduler
-    vTaskEndScheduler();
+    // Required at the end of each test job
+    end_test_task(xFilesystemHandler);
+
 }
 void test_log_single_error_job( void ) {
-
-    BaseType_t filesystem_task_status = xTaskCreate(filesystem_task,
-                                        "FILESYSTEM",
-                                        1024,
-                                        NULL,
-                                        1,
-                                        NULL);
-
-    BaseType_t testing_task_status = xTaskCreate(test_log_single_error_testtask,
-                                        "TEST", 
-                                        1024, 
-                                        NULL, 
-                                        1,
-                                        NULL); 
-
-    // Start Filesystem scheduler and test task
-    vTaskStartScheduler();
-
-    TEST_ASSERT(true); // Make sure the scheduler exits properly
+    TEST_MESSAGE("Starting test test_log_single_error_job");
+    test_log_rtos_scheduler_begin(test_log_single_error_testtask);
 }
 
 
-// Log errros up to MAX_ERROR_LOG_MESSAGES and check if the most recent errors are retrieved correctly
+/*
+*  Log errros up to ERROR_LOGS_FS_ALLOCATION and check if the most recent errors are retrieved correctly
+*/
 static void test_log_max_error_testtask( void *pvParameters ) {
 
-    logln_info("Starting task");
+    TaskHandle_t xFilesystemHandler = (TaskHandle_t)pvParameters;
 
-    for (int i = 0; i < MAX_ERROR_LOG_MESSAGES; i++) {
+    int max_allowed_logged_errors = ERROR_LOGS_FS_ALLOCATION / MAX_ERROR_LOG_STR_SIZE;
+
+    for (int i = 0; i < max_allowed_logged_errors; i++) {
         logln_error("Test error%d", i); // Log error with index
 
         // Check if the last error is updated correctly
@@ -62,27 +91,54 @@ static void test_log_max_error_testtask( void *pvParameters ) {
         TEST_ASSERT_EQUAL_STRING(expected_error_str, error_str);
     }
 
-    // Kill scheduler
-    vTaskEndScheduler();
+    end_test_task(xFilesystemHandler);
+
 }
 void test_log_max_error_job( void ) {
-
     TEST_MESSAGE("Starting test test_log_max_error_job");
+    test_log_rtos_scheduler_begin(test_log_max_error_testtask);
+}
 
-    BaseType_t filesystem_task_status = xTaskCreate(filesystem_task,
-                                        "FILESYSTEM",
-                                        1024,
-                                        NULL,
-                                        1,
-                                        NULL);
 
-    BaseType_t testing_task_status = xTaskCreate(test_log_max_error_testtask,
-                                        "TEST", 
-                                        1024, 
-                                        NULL, 
-                                        1,
-                                        NULL); 
+/*
+* Log errors past the ERROR_LOGS_FS_ALLOCATION and check if the error file's size is being maintained and updated correctly
+*/
+static void test_log_file_rotation_testtask( void *pvParameters ) {
 
-    // Start Filesystem scheduler and test task
-    vTaskStartScheduler();
+    TaskHandle_t xFilesystemHandler = (TaskHandle_t)pvParameters;
+
+    int max_allowed_logged_errors = ERROR_LOGS_FS_ALLOCATION / MAX_ERROR_LOG_STR_SIZE;
+
+    // Log max lines allowed * 2 errors to make sure rotation is working
+    int expected_file_size = 1; // File size starts at 1
+    for (int i = 0; i < max_allowed_logged_errors * 2; i++) {
+        char expected_error_str[MAX_ERROR_LOG_STR_SIZE];
+        sprintf(expected_error_str, "Test error%d", i % 10); // Only 1 digit to have uniform string size but unique strings
+        
+        logln_error("%s", expected_error_str); // Log error with index
+
+        // If the error count in the file is < max error messages, add to the length, otherwise, it should not change
+        if (i < max_allowed_logged_errors) {
+            expected_file_size += strlen(expected_error_str) + 1; // +1 for newline
+        }
+        // Check file size
+        FILINFO file_info;
+        stat(ERROR_LOG_FILE_PATH, &file_info);
+        
+        TEST_ASSERT_EQUAL(expected_file_size, file_info.fsize);
+
+        // Check if the last error is updated correctly
+        char error_str[MAX_ERROR_LOG_STR_SIZE];
+        get_most_recent_logged_error(error_str);
+
+        // Compare strings
+        TEST_ASSERT_EQUAL_STRING(expected_error_str, error_str);
+    }
+
+    end_test_task(xFilesystemHandler);
+
+}
+void test_log_file_rotation_job( void ) {
+    TEST_MESSAGE("Starting test test_log_file_rotation_job");
+    test_log_rtos_scheduler_begin(test_log_file_rotation_testtask);
 }

--- a/main/test/unit/log/log_test_unittest.c
+++ b/main/test/unit/log/log_test_unittest.c
@@ -54,7 +54,7 @@ static void test_log_single_error_testtask( void *pvParameters ) {
     // Log error
     logln_error("Test error");
     char error_str[MAX_ERROR_LOG_STR_SIZE];
-    get_most_recent_logged_error(error_str);
+    get_most_recent_logged_error(error_str, MAX_ERROR_LOG_STR_SIZE);
 
     // Compare strings
     TEST_ASSERT_EQUAL_STRING("Test error", error_str);
@@ -83,7 +83,7 @@ static void test_log_max_error_testtask( void *pvParameters ) {
 
         // Check if the last error is updated correctly
         char error_str[MAX_ERROR_LOG_STR_SIZE];
-        get_most_recent_logged_error(error_str);
+        get_most_recent_logged_error(error_str, MAX_ERROR_LOG_STR_SIZE);
 
         // Compare strings
         char expected_error_str[MAX_ERROR_LOG_STR_SIZE];
@@ -129,7 +129,7 @@ static void test_log_file_rotation_testtask( void *pvParameters ) {
 
         // Check if the last error is updated correctly
         char error_str[MAX_ERROR_LOG_STR_SIZE];
-        get_most_recent_logged_error(error_str);
+        get_most_recent_logged_error(error_str, MAX_ERROR_LOG_STR_SIZE);
 
         // Compare strings
         TEST_ASSERT_EQUAL_STRING(expected_error_str, error_str);

--- a/main/test/unit/log/log_test_unittest.c
+++ b/main/test/unit/log/log_test_unittest.c
@@ -1,0 +1,88 @@
+#include "FreeRTOS.h"
+
+#include "unity.h"
+
+#include "filesystem.h"
+#include "log.h"
+
+// Log a single error and check if it is retrieved correctly
+static void test_log_single_error_testtask( void *pvParameters ) {
+
+    TEST_MESSAGE("Starting test test_log_single_error_testtask");
+
+    // Log error
+    logln_error("Test error");
+    char error_str[MAX_ERROR_LOG_STR_SIZE];
+    get_most_recent_logged_error(error_str);
+
+    // Compare strings
+    TEST_ASSERT_EQUAL_STRING("Test error", error_str);
+
+    // Kill scheduler
+    vTaskEndScheduler();
+}
+void test_log_single_error_job( void ) {
+
+    BaseType_t filesystem_task_status = xTaskCreate(filesystem_task,
+                                        "FILESYSTEM",
+                                        1024,
+                                        NULL,
+                                        1,
+                                        NULL);
+
+    BaseType_t testing_task_status = xTaskCreate(test_log_single_error_testtask,
+                                        "TEST", 
+                                        1024, 
+                                        NULL, 
+                                        1,
+                                        NULL); 
+
+    // Start Filesystem scheduler and test task
+    vTaskStartScheduler();
+
+    TEST_ASSERT(true); // Make sure the scheduler exits properly
+}
+
+
+// Log errros up to MAX_ERROR_LOG_MESSAGES and check if the most recent errors are retrieved correctly
+static void test_log_max_error_testtask( void *pvParameters ) {
+
+    logln_info("Starting task");
+
+    for (int i = 0; i < MAX_ERROR_LOG_MESSAGES; i++) {
+        logln_error("Test error%d", i); // Log error with index
+
+        // Check if the last error is updated correctly
+        char error_str[MAX_ERROR_LOG_STR_SIZE];
+        get_most_recent_logged_error(error_str);
+
+        // Compare strings
+        char expected_error_str[MAX_ERROR_LOG_STR_SIZE];
+        sprintf(expected_error_str, "Test error%d", i);
+        TEST_ASSERT_EQUAL_STRING(expected_error_str, error_str);
+    }
+
+    // Kill scheduler
+    vTaskEndScheduler();
+}
+void test_log_max_error_job( void ) {
+
+    TEST_MESSAGE("Starting test test_log_max_error_job");
+
+    BaseType_t filesystem_task_status = xTaskCreate(filesystem_task,
+                                        "FILESYSTEM",
+                                        1024,
+                                        NULL,
+                                        1,
+                                        NULL);
+
+    BaseType_t testing_task_status = xTaskCreate(test_log_max_error_testtask,
+                                        "TEST", 
+                                        1024, 
+                                        NULL, 
+                                        1,
+                                        NULL); 
+
+    // Start Filesystem scheduler and test task
+    vTaskStartScheduler();
+}

--- a/main/utilities/include/log.h
+++ b/main/utilities/include/log.h
@@ -1,10 +1,15 @@
 #pragma once
 
 /* DEFINES */
-#define MAX_LOG_STR_SIZE 0x1000U
-#define MAX_ERROR_LOG_STR_SIZE 0x100U // More limited as it is to be logged in our MRAM - used only for writing the logs to files
-#define MAX_ERROR_LOG_MESSAGES 3 // Max number of error messages that can be logged
+#define MAX_LOG_STR_SIZE 0x1000U // For info and warn
+// For a single error, more limited as it logged in MRAM - used only for writing the logs to files
+// To find max error messages allowed to be logged, divide ERROR_LOGS_FS_ALLOCATION by MAX_ERROR_LOG_STR_SIZE (see filesystem.h)
+#define MAX_ERROR_LOG_STR_SIZE 0x100U // This should be a dividend of ERROR_LOGS_FS_ALLOCATION (see filesystem.h)
 
+
+//#define MAX_ERROR_LOG_MESSAGES 3 // Max number of error messages that can be logged
+
+static const char ERROR_LOG_FILE_PATH[] = "/logs/log.txt";
 
 /* USER FUNCTIONS */
 
@@ -49,4 +54,5 @@ void _log(const char *str, ...);
 void _write_log(const char *bytes, size_t size);
 
 // ONLY for use within logln_error
+// There will be a MAX of  ERROR_LOGS_FS_ALLOCATION / MAX_ERROR_LOG_STR_SIZE lines at a time logged to the error file
 void write_error_log(char *str);

--- a/main/utilities/include/log.h
+++ b/main/utilities/include/log.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "telemetry.h"
+#include <stdbool.h>
+
 /* DEFINES */
 #define MAX_LOG_STR_SIZE 0x1000U // For info and warn
 // For a single error, more limited as it logged in MRAM - used only for writing the logs to files
@@ -24,20 +27,19 @@ void print_banner();
 
 // Used for general printing to console
 #define log_gen(f_, ...) \
-    logln(f_, ##__VA_ARGS__);
+    _log(false, f_ "\n", ##__VA_ARGS__);
 
 #define logln_info(f_, ...) \
-    logln("[INFO] " f_, ##__VA_ARGS__);
+    _log(false, "[INFO] " f_ "\n", ##__VA_ARGS__);
 
 #define logln_warn(f_, ...) \
-    logln("[WARN] " f_, ##__VA_ARGS__);
+    _log(false, "[WARN] " f_ "\n", ##__VA_ARGS__);
 
 #define logln_error(f_, ...) \
-    _log_error_fs(f_, ##__VA_ARGS__); \
-    _log_error("[ERROR] " f_, ##__VA_ARGS__);
+    _log(true, "[ERROR] " f_ "\n", ##__VA_ARGS__);
 
 #define logln(f_, ...) \
-    _log(f_ "\n", ##__VA_ARGS__);
+    _log(false, f_ "\n", ##__VA_ARGS__);
 
 const char *get_current_task_name();
 
@@ -50,7 +52,7 @@ int get_most_recent_logged_error(char *out_log_str, int out_log_str_size);
 
 /* INTERNAL FUNCTIONS */
 
-void _log(const char *str, ...);
+void _log(bool is_error, const char *str, ...);
 
 void _write_log(const char *bytes, size_t size);
 

--- a/main/utilities/include/log.h
+++ b/main/utilities/include/log.h
@@ -2,6 +2,9 @@
 
 /* DEFINES */
 #define MAX_LOG_STR_SIZE 0x1000U
+#define MAX_ERROR_LOG_STR_SIZE 0x100U // More limited as it is to be logged in our MRAM - used only for writing the logs to files
+#define MAX_ERROR_LOG_MESSAGES 3 // Max number of error messages that can be logged
+
 
 /* USER FUNCTIONS */
 
@@ -37,3 +40,5 @@ const char *get_current_task_name();
 void _log(const char *str, ...);
 
 void _write_log(const char *bytes, size_t size);
+
+void write_error_log(char *str);

--- a/main/utilities/include/log.h
+++ b/main/utilities/include/log.h
@@ -35,6 +35,13 @@ void print_banner();
 
 const char *get_current_task_name();
 
+/*
+*  Get most recent logged error
+*  Log is output to out_log_str
+*  Returns length of the out_log_str
+*/
+int get_most_recent_logged_error(char *out_log_str);
+
 /* INTERNAL FUNCTIONS */
 
 void _log(const char *str, ...);

--- a/main/utilities/include/log.h
+++ b/main/utilities/include/log.h
@@ -48,4 +48,5 @@ void _log(const char *str, ...);
 
 void _write_log(const char *bytes, size_t size);
 
+// ONLY for use within logln_error
 void write_error_log(char *str);

--- a/main/utilities/include/log.h
+++ b/main/utilities/include/log.h
@@ -33,7 +33,8 @@ void print_banner();
     logln("[WARN] " f_, ##__VA_ARGS__);
 
 #define logln_error(f_, ...) \
-    logln("[ERROR] " f_, ##__VA_ARGS__);
+    _log_error_fs(f_, ##__VA_ARGS__); \
+    _log_error("[ERROR] " f_, ##__VA_ARGS__);
 
 #define logln(f_, ...) \
     _log(f_ "\n", ##__VA_ARGS__);
@@ -45,7 +46,7 @@ const char *get_current_task_name();
 *  Log is output to out_log_str
 *  Returns length of the out_log_str
 */
-int get_most_recent_logged_error(char *out_log_str);
+int get_most_recent_logged_error(char *out_log_str, int out_log_str_size);
 
 /* INTERNAL FUNCTIONS */
 

--- a/main/utilities/src/hb_tlm_log.c
+++ b/main/utilities/src/hb_tlm_log.c
@@ -10,7 +10,7 @@
 // Tlm files of the size specified by MAX_HB_TLM_FILE_SIZE (see filesystem.h) will continue to be created until creating a new file of said size will surpase or equal this limit
 //      Once this limit is reached, the oldest log will be deleted before a new one is created
 // This should be an even dividend of HEARTBEAT_TLM_FS_ALLOCATION (see filesystem.h)
-#define MAX_HB_TLM_FILE_SIZE 2000 // About an 15 minute of tlm, small enough to read into memory for playback
+#define MAX_HB_TLM_FILE_SIZE 1000 // A reasonable amount to read into memory (this is currently only read into memory by the command task from the heartbeat playback)
 
 void log_heartbeat_tlm(heartbeat_telemetry_t payload) {
 

--- a/main/utilities/src/hb_tlm_log.c
+++ b/main/utilities/src/hb_tlm_log.c
@@ -37,7 +37,7 @@ void log_heartbeat_tlm(heartbeat_telemetry_t payload) {
     }
     
     // Write to this indexed file
-    char filename[20];
+    char filename[MAX_PATH_SIZE];
     snprintf(filename, sizeof(filename), "/tlm/%d.bin", file_info_buf.file_index);
     write_file(filename, (char*)&payload, sizeof(payload), true); // append - this will eaither make the file if it does not exist or append to it if it does
 

--- a/main/utilities/src/hb_tlm_log.c
+++ b/main/utilities/src/hb_tlm_log.c
@@ -6,12 +6,11 @@
 #include <string.h>
 
 // Size (bytes) that a heartbeat telemetry file can be until a new one should be used
-// If writing a new telemetry entry causes the file to go over this amount, a new file is made
+//      If writing a new telemetry entry causes the file to go over this amount, a new file is made
+// Tlm files of the size specified by MAX_HB_TLM_FILE_SIZE (see filesystem.h) will continue to be created until creating a new file of said size will surpase or equal this limit
+//      Once this limit is reached, the oldest log will be deleted before a new one is created
+// This should be an even dividend of HEARTBEAT_TLM_FS_ALLOCATION (see filesystem.h)
 #define MAX_HB_TLM_FILE_SIZE 2000 // About an 15 minute of tlm, small enough to read into memory for playback
-
-// Tlm files of the size specified by MAX_HB_TLM_FILE_SIZE will continue to be created until creating a new file of said size will surpase or equal this limit
-// Once this limit is reached, the oldest log will be deleted before a new one is created
-#define MAX_HB_TLM_TOTAL_SIZE 10000 //1250000 // 10 MBit to bytes
 
 void log_heartbeat_tlm(heartbeat_telemetry_t payload) {
 
@@ -51,7 +50,7 @@ void log_heartbeat_tlm(heartbeat_telemetry_t payload) {
         file_info_buf.directory_size += MAX_HB_TLM_FILE_SIZE; // Only increase once the file is full, it doesn't get checked until the file is full anyway
 
         // See if there is enough space for the new file, otherwise delete the oldest file
-        if (file_info_buf.directory_size + MAX_HB_TLM_FILE_SIZE > MAX_HB_TLM_TOTAL_SIZE) {
+        if (file_info_buf.directory_size + MAX_HB_TLM_FILE_SIZE > HEARTBEAT_TLM_FS_ALLOCATION) {
             // Delete the oldest file in the directory an increase the oldest file counter by 1
             char oldest_filename[20];
             snprintf(oldest_filename, sizeof(oldest_filename), "/tlm/%d.bin", file_info_buf.oldest_file_index);

--- a/main/utilities/src/log.c
+++ b/main/utilities/src/log.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <unistd.h>
+#include <string.h>
 
 #include "FreeRTOS.h"
 #include "queue.h"
@@ -9,6 +10,7 @@
 
 #include "telemetry.h"
 #include "log.h"
+#include "filesystem.h"
 
 void print_banner() {
     logln(
@@ -43,10 +45,16 @@ void _log(const char *str, ...) {
     packet->size = strsize;
     va_end(args);
 
+    if (strncmp(packet->str, "[ERROR]", 7) == 0) {
+        printf("\n IS ERROR: %s", packet->str);
+        // Write error to file without "[ERROR]"
+        write_error_log(packet->str);
+    }
+
 #ifdef SIMULATOR
     // write to stdout
-    //write(1, packet->str, strsize);
-    send_telemetry(LOG, (char*)packet, sizeof(log_telemetry_t) + strsize + 1);
+    write(1, packet->str, strsize);
+    //send_telemetry(LOG, (char*)packet, sizeof(log_telemetry_t) + strsize + 1);
 #else
     // send to telemetry task
     send_telemetry(LOG, (char*)packet, sizeof(log_telemetry_t) + strsize + 1);
@@ -58,8 +66,79 @@ void _log(const char *str, ...) {
 
 void _write_log(const char *bytes, size_t size) {
 
-    	log_telemetry_t packet;
+    log_telemetry_t packet;
     memcpy(packet.str, bytes, size);
     packet.size = size;
     send_telemetry(LOG, (char*)&packet, sizeof(log_telemetry_t) + size);
+}
+
+void write_error_log(char *str) {
+
+    // First, truncate string for log storage
+    if (strlen(str) > MAX_ERROR_LOG_STR_SIZE) {
+        str[MAX_ERROR_LOG_STR_SIZE] = '\0';
+    }
+
+    // See if tlm directory exists
+    if (!dir_exists("/logs")) {
+        make_dir("/logs");
+
+        // Write to new log file and add this string
+        printf("STRING LEN: %d\n", strlen(str));
+        write_file("/logs/errors.txt", str, strlen(str) + 1, false); // +1 for end of string
+
+        char errorlog_buf2[(MAX_ERROR_LOG_STR_SIZE + 2) * MAX_ERROR_LOG_MESSAGES]; // +1 because there is no \0 but there will be the \n
+        int bytes_read2 = read_file("/logs/errors.txt", errorlog_buf2, (MAX_LOG_STR_SIZE + 1) * 5);
+        if (bytes_read2 < 0) {
+            logln_error("Error reading errors.txt here");
+            return;
+        }
+        printf("Error log file:\n%s\n\n\n", errorlog_buf2);
+
+        return;
+    }
+
+    // Else - read the current log file and append to it - remove lines if it is too long - only keep 4 lines of errors at a time
+    char errorlog_buf[(MAX_ERROR_LOG_STR_SIZE + 2) * MAX_ERROR_LOG_MESSAGES]; // +1 because there is no \0 but there will be the \n
+    int bytes_read = read_file("/logs/errors.txt", errorlog_buf, (MAX_LOG_STR_SIZE + 1) * 5);
+    if (bytes_read < 0) {
+        logln_error("Error reading errorlog.txt");
+        return;
+    }
+
+    // Append str to the end of buff - logs already have newlines
+    strcat(errorlog_buf, str);
+
+    // Count the number of lines
+    int line_count = 0;
+    for (int i = 0; i < strlen(errorlog_buf); i++) {
+        if (errorlog_buf[i] == '\n') {
+            line_count++;
+        }
+    }
+
+    // If there are more than MAX_ERROR_LOG_MESSAGES lines, remove the first line
+    if (line_count > MAX_ERROR_LOG_MESSAGES) {
+        char *first_newline = strchr(errorlog_buf, '\n'); // Get first newline
+        if (first_newline != NULL) {
+            memmove(errorlog_buf, first_newline + 1, strlen(first_newline));
+        }
+    }
+
+    // Rewrite to file
+    write_file("/logs/errors.txt", errorlog_buf, strlen(errorlog_buf), false);
+
+
+    printf("ERROR logs: ");
+    list_dir("/logs");
+
+    // For testing purposes, read and print the error log file
+    char errorlog_buf2[(MAX_ERROR_LOG_STR_SIZE + 2) * MAX_ERROR_LOG_MESSAGES]; // +1 because there is no \0 but there will be the \n
+    int bytes_read2 = read_file("/logs/errors.txt", errorlog_buf2, (MAX_LOG_STR_SIZE + 1) * 5);
+    if (bytes_read2 < 0) {
+        logln_error("Error reading errors.txt here");
+        return;
+    }
+    printf("Error log file:\n%s\n\n\n", errorlog_buf2);
+
 }

--- a/main/utilities/src/log.c
+++ b/main/utilities/src/log.c
@@ -99,7 +99,7 @@ void write_error_log(char *str) {
         return;
     }
 
-    // Append str to the end of buff - logs already have newlines
+    // Append str to the end of buff - logs already have newlines and str will have max size of MAX_ERROR_LOG_STR_SIZE
     strcat(errorlog_buf, str);
 
     // Count the number of lines


### PR DESCRIPTION
Added Error logging. Errors messages (excluding the "[ERROR] " part of the string) will now be logged to the mram and be retrieved for ack packets.
Ack tlm packets are now transmitted after every command. FSW ping command also added

Tested with simulator (and new unit tests) along with COSMOS
Compatible with this GSE commit: https://github.com/ASU-SDSL/coconut-gse/commit/a1944f70aa6ff52e3cabacfc5b6722d29924c2a2