### PR TITLE
OneWire Temp Sensors working with critical sections 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,6 +19,6 @@
 [submodule "lib/libspacepacket"]
 	path = lib/libspacepacket
 	url = https://github.com/mzakocs/libspacepacket.git
-[submodule "lib/OneWire"]
-	path = lib/OneWire
-	url = git@github.com:tylermnielsen/OneWire.git
+[submodule "lib/pico-one-wire-ds18b"]
+	path = lib/pico-one-wire-ds18b
+	url = https://github.com/ASU-SDSL/pico-one-wire-ds18b.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "lib/libspacepacket"]
 	path = lib/libspacepacket
 	url = https://github.com/mzakocs/libspacepacket.git
+[submodule "lib/OneWire"]
+	path = lib/OneWire
+	url = git@github.com:tylermnielsen/OneWire.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ ENDIF()
 # Include libraries
 add_subdirectory(${CMAKE_SOURCE_DIR}/lib/fatfs/ build)
 add_subdirectory(${CMAKE_SOURCE_DIR}/lib/libspacepacket/)
-add_subdirectory(${CMAKE_SOURCE_DIR}/lib/OneWire/)
+add_subdirectory(${CMAKE_SOURCE_DIR}/lib/pico-one-wire-ds18b/)
 IF (NOT ${DESKTOP_BUILD})
     add_subdirectory(${CMAKE_SOURCE_DIR}/lib/RadioLib)
 ENDIF()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ ENDIF()
 # Include libraries
 add_subdirectory(${CMAKE_SOURCE_DIR}/lib/fatfs/ build)
 add_subdirectory(${CMAKE_SOURCE_DIR}/lib/libspacepacket/)
+add_subdirectory(${CMAKE_SOURCE_DIR}/lib/OneWire/)
 IF (NOT ${DESKTOP_BUILD})
     add_subdirectory(${CMAKE_SOURCE_DIR}/lib/RadioLib)
 ENDIF()

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -33,6 +33,7 @@ set(SOURCES
     ${MAIN_DIRECTORY}/drivers/src/rtc_ds3231.c
     ${MAIN_DIRECTORY}/drivers/src/mag_lis3mdltr.c
     ${MAIN_DIRECTORY}/drivers/src/vega_ant.c
+    ${MAIN_DIRECTORY}/drivers/src/ds18b_onewire.cpp
 )
 
 # build certain files depending on simulator build
@@ -64,6 +65,8 @@ set (LINK_LIBS
     FreeRTOS
     FatFs
     libspacepacket
+
+    OneWireLib
 )
 
 IF (${DESKTOP_BUILD})

--- a/main/drivers/include/ds18b_onewire.h
+++ b/main/drivers/include/ds18b_onewire.h
@@ -9,14 +9,15 @@
 extern "C" {
 #endif
 
-const uint8_t DS18B_U100[8] = {0x28, 0x0A, 0xAF, 0xD8, 0x0F, 0x00, 0x00, 0xCF};  // 28 A AF D8 F 0 0 CF
-const uint8_t DS18B_U102[8] = {0x28, 0x1C, 0xAF, 0xD8, 0x0F, 0x00, 0x00, 0x26};  // 28 1C AF D8 F 0 0 26
-const uint8_t DS18B_U104[8] = {0x28, 0x11, 0xAF, 0xD8, 0x0F, 0x00, 0x00, 0x6C};  // 28 11 AF D8 F 0 0 6C
+extern const uint8_t DS18B_U100[8]; 
+extern const uint8_t DS18B_U102[8];
+extern const uint8_t DS18B_U104[8];
 
 uint8_t ds18b_read_temp(float* data);
 // void debug_sample_loop(); // delete 
 uint8_t ds18b_start_conversion(); 
 float ds18b_get_temp(const uint8_t* addr); 
+int16_t ds18b_get_temp_raw(const uint8_t* addr); 
 
 #ifdef __cplusplus
 }

--- a/main/drivers/include/ds18b_onewire.h
+++ b/main/drivers/include/ds18b_onewire.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <stdint.h>
+#include "pico/stdlib.h"
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+uint8_t ds18b_read_temp(float* data_arr, uint8_t len);
+void debug_sample_loop(); // delete 
+
+#ifdef __cplusplus
+}
+#endif

--- a/main/drivers/include/ds18b_onewire.h
+++ b/main/drivers/include/ds18b_onewire.h
@@ -9,8 +9,14 @@
 extern "C" {
 #endif
 
+const uint8_t DS18B_U100[8] = {0x28, 0x0A, 0xAF, 0xD8, 0x0F, 0x00, 0x00, 0xCF};  // 28 A AF D8 F 0 0 CF
+const uint8_t DS18B_U102[8] = {0x28, 0x1C, 0xAF, 0xD8, 0x0F, 0x00, 0x00, 0x26};  // 28 1C AF D8 F 0 0 26
+const uint8_t DS18B_U104[8] = {0x28, 0x11, 0xAF, 0xD8, 0x0F, 0x00, 0x00, 0x6C};  // 28 11 AF D8 F 0 0 6C
+
 uint8_t ds18b_read_temp(float* data);
-void debug_sample_loop(); // delete 
+// void debug_sample_loop(); // delete 
+uint8_t ds18b_start_conversion(); 
+float ds18b_get_temp(const uint8_t* addr); 
 
 #ifdef __cplusplus
 }

--- a/main/drivers/include/ds18b_onewire.h
+++ b/main/drivers/include/ds18b_onewire.h
@@ -2,13 +2,14 @@
 
 #include <stdint.h>
 #include "pico/stdlib.h"
-#include <stdio.h>
+#include <FreeRTOS.h>
+#include "task.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-uint8_t ds18b_read_temp(float* data_arr, uint8_t len);
+uint8_t ds18b_read_temp(float* data);
 void debug_sample_loop(); // delete 
 
 #ifdef __cplusplus

--- a/main/drivers/src/ds18b_onewire.cpp
+++ b/main/drivers/src/ds18b_onewire.cpp
@@ -25,7 +25,7 @@ OneWire ds(ONE_WIRE_PIN,
             custom_interrupts_hal, 
             custom_noInterrupts_hal);  // on pin 10 (a 4.7K resistor is necessary)
 
-#if ONE_WIRE_DEBUG 
+#if ONE_WIRE_DEBUG
 #include <stdio.h>
 void debug_sample_loop() {
     uint8_t i;
@@ -213,33 +213,7 @@ uint8_t ds18b_start_conversion(){
 
 
 float ds18b_get_temp(const uint8_t* addr){
-    // if it hasn't been long enough since the conversion was started 
-    // wait for it to be long enough 
-    uint32_t now = to_ms_since_boot(get_absolute_time()); 
-    if(now - ds18b_conversion_time < MIN_CONVERSION_TIME_MS){
-        vTaskDelay(pdMS_TO_TICKS(MIN_CONVERSION_TIME_MS - (now - ds18b_conversion_time)));
-    }
-
-    uint8_t present = ds.reset(); 
-    ds.select(addr); 
-    ds.write(0xBE); // read Scratchpad
-
-    uint8_t data[9]; 
-    for(int i = 0; i < 9; i++){
-        data[i] = ds.read(); 
-    }
-
-    int16_t raw = (data[1] << 8) | data[0]; 
-    
-    uint8_t cfg = (data[4] & 0x60);
-    // at lower res, the low bits are undefined, so let's zero them
-    if (cfg == 0x00)
-        raw = raw & ~7;  // 9 bit resolution, 93.75 ms
-    else if (cfg == 0x20)
-        raw = raw & ~3;  // 10 bit res, 187.5 ms
-    else if (cfg == 0x40)
-        raw = raw & ~1;  // 11 bit res, 375 ms
-    //// default is 12 bit resolution, 750 ms conversion time
+    int16_t raw = ds18b_get_temp_raw(addr); 
     
     float celsius = (float)raw / 16.0;
 

--- a/main/drivers/src/ds18b_onewire.cpp
+++ b/main/drivers/src/ds18b_onewire.cpp
@@ -1,0 +1,107 @@
+
+#include "ds18b_onewire.h"
+#include "OneWire.h"
+
+OneWire ds(16);  // on pin 10 (a 4.7K resistor is necessary)
+
+uint8_t ds18b_read_temp(float* data_arr, uint8_t len){
+    return 0; 
+}
+
+void debug_sample_loop() {
+    uint8_t i;
+    uint8_t present = 0;
+    uint8_t type_s;
+    uint8_t data[9];
+    uint8_t addr[8];
+    float celsius, fahrenheit;
+
+    if (!ds.search(addr)) {
+        printf("No more addresses.");
+        printf("\n");
+        ds.reset_search();
+        busy_wait_ms(250);
+        return;
+    }
+
+    printf("ROM =");
+    for (i = 0; i < 8; i++) {
+        printf(" %x", addr[i]);
+    }
+
+    if (OneWire::crc8(addr, 7) != addr[7]) {
+        printf("CRC is not valid!\n");
+        return;
+    }
+
+    // the first ROM byte indicates which chip
+    switch (addr[0]) {
+        case 0x10:
+        printf("  Chip = DS18S20\n");  // or old DS1820
+        type_s = 1;
+        break;
+        case 0x28:
+        printf("  Chip = DS18B20\n");
+        type_s = 0;
+        break;
+        case 0x22:
+        printf("  Chip = DS1822\n");
+        type_s = 0;
+        break;
+        default:
+        printf("Device is not a DS18x20 family device.\n");
+        return;
+    }
+
+    ds.reset();
+    ds.select(addr);
+    ds.write(0x44, 1);  // start conversion, with parasite power on at the end
+
+    busy_wait_ms(1000);  // maybe 750ms is enough, maybe not
+
+    present = ds.reset();
+    ds.select(addr);
+    ds.write(0xBE);  // Read Scratchpad
+
+    printf("  Data = ");
+    printf("%x", present);
+    printf(" ");
+    for (i = 0; i < 9; i++) {  // we need 9 bytes
+        data[i] = ds.read();
+        printf("%x", data[i]);
+        printf(" ");
+    }
+    printf(" CRC=");
+    printf("%x", OneWire::crc8(data, 8));
+    printf("\n");
+
+    // Convert the data to actual temperature
+    // because the result is a 16 bit signed integer, it should
+    // be stored to an "int16_t" type, which is always 16 bits
+    // even when compiled on a 32 bit processor.
+    int16_t raw = (data[1] << 8) | data[0];
+    if (type_s) {
+        raw = raw << 3;  // 9 bit resolution default
+        if (data[7] == 0x10) {
+        // "count remain" gives full 12 bit resolution
+        raw = (raw & 0xFFF0) + 12 - data[6];
+        }
+    } else {
+        uint8_t cfg = (data[4] & 0x60);
+        // at lower res, the low bits are undefined, so let's zero them
+        if (cfg == 0x00)
+        raw = raw & ~7;  // 9 bit resolution, 93.75 ms
+        else if (cfg == 0x20)
+        raw = raw & ~3;  // 10 bit res, 187.5 ms
+        else if (cfg == 0x40)
+        raw = raw & ~1;  // 11 bit res, 375 ms
+        //// default is 12 bit resolution, 750 ms conversion time
+    }
+    celsius = (float)raw / 16.0;
+    fahrenheit = celsius * 1.8 + 32.0;
+    printf("  Temperature = ");
+    printf("%f", celsius);
+    printf(" Celsius, ");
+    printf("%f", fahrenheit);
+    printf(" Fahrenheit\n");
+}

--- a/main/tasks/gse/gse.c
+++ b/main/tasks/gse/gse.c
@@ -10,7 +10,6 @@
 #include "ina219.h"
 #include "log.h"
 #include "gse.h"
-#include "ds18b_onewire.h"
 
 void gse_queue_message(char* buffer, size_t size) {
     // write to picosdk usb uart interface

--- a/main/tasks/gse/gse.c
+++ b/main/tasks/gse/gse.c
@@ -21,23 +21,6 @@ void gse_task(void *pvParameters) {
     // Initialize USB UART
     stdio_init_all();
 
-    while(1){
-        printf("looooooop\n"); 
-
-        float data = 0; 
-        uint8_t res = ds18b_read_temp(&data);
-        // if on reset read again 
-        if(res == 1){
-            printf("seen all devices\n"); 
-            res = ds18b_read_temp(&data); 
-        }
-
-        printf("res = %d\n", res); 
-        printf("data = %f\n", data); 
-
-        // debug_sample_loop(); 
-    }
-
     // Start listening for USB UART bytes
     while (true) {
 

--- a/main/tasks/gse/gse.c
+++ b/main/tasks/gse/gse.c
@@ -10,6 +10,7 @@
 #include "ina219.h"
 #include "log.h"
 #include "gse.h"
+#include "ds18b_onewire.h"
 
 void gse_queue_message(char* buffer, size_t size) {
     // write to picosdk usb uart interface
@@ -20,8 +21,26 @@ void gse_task(void *pvParameters) {
     // Initialize USB UART
     stdio_init_all();
 
+    while(1){
+        printf("looooooop\n"); 
+
+        float data = 0; 
+        uint8_t res = ds18b_read_temp(&data);
+        // if on reset read again 
+        if(res == 1){
+            printf("seen all devices\n"); 
+            res = ds18b_read_temp(&data); 
+        }
+
+        printf("res = %d\n", res); 
+        printf("data = %f\n", data); 
+
+        // debug_sample_loop(); 
+    }
+
     // Start listening for USB UART bytes
     while (true) {
+
         // Wait on bytes from stdin
         char c;
         int len = readbytes_usb(&c, 1);  

--- a/main/tasks/steve/jobs/heartbeat_job.c
+++ b/main/tasks/steve/jobs/heartbeat_job.c
@@ -16,10 +16,16 @@
 #include "radio.h"
 #include "max17048.h"
 #include "hb_tlm_log.h"
+#include "ds18b_onewire.h"
 
 void heartbeat_telemetry_job(void* unused) {
     // Create heartbeat struct
     heartbeat_telemetry_t payload;
+
+    // send signal to start ds18b temperature conversions
+    // this takes 750-1000ms so triggering it now to have 
+    // some of that wait time be used to get other sensor values 
+    ds18b_start_conversion(); 
 
     // logln_info("%s", get_current_task_name());
 
@@ -165,6 +171,11 @@ void heartbeat_telemetry_job(void* unused) {
     payload.which_radio = radio_which(); 
     payload.rfm_state = radio_get_RFM_state(); 
     payload.sx_state = radio_get_SX_state(); 
+
+    // set ds18b temps 
+    payload.u100_temp = ds18b_get_temp_raw(DS18B_U100); 
+    payload.u102_temp = ds18b_get_temp_raw(DS18B_U102); 
+    payload.u104_temp = ds18b_get_temp_raw(DS18B_U104); 
     
     // Send it
     send_telemetry(HEARTBEAT, (char*)&payload, sizeof(payload));

--- a/main/tasks/telemetry/telemetry.h
+++ b/main/tasks/telemetry/telemetry.h
@@ -74,6 +74,9 @@ typedef struct __attribute__((__packed__)) {
     int16_t mag_z;
     int16_t mag_temp;
     uint8_t vega_ant_status;
+    int16_t u100_temp; 
+    int16_t u102_temp; 
+    int16_t u104_temp; 
 
     int16_t rfm_state; 
     int16_t sx_state; 


### PR DESCRIPTION
Works with eps DS18B sensors. This doesn't have the option to turn off the critical sections yet because having that in a if causes problems with the code freezing, but I want to merge it in because I think with the solar panels having the DS18B as well we'll need that code for at least those. Also I added the sensors temperatures to the heartbeat packet and it does work so this will make sure it stays updated with the gse packet definitions 