### PR TITLE
Draft: Integrating Callsign into telemetry bytes

### DIFF
--- a/main/tasks/command/command.c
+++ b/main/tasks/command/command.c
@@ -247,6 +247,14 @@ void command_task(void* unused_arg) {
         // logln_info("Received all sync bytes!");
         // TODO: Add better error checks and handling here
         // Gather spacepacket header bytes
+
+        //Edit by KB & Henry: we also receive in the callsign bytes
+        uint8_t callsign_bytes[CALLSIGN_SIZE];
+        for(int i = 0; i < CALLSIGN_SIZE; i++) {
+            xQueueReceive(command_byte_queue, &callsign_bytes[i], portMAX_DELAY);
+        }
+        //TODO: Do something with the received callsign, like maybe debug print or something.
+
         uint8_t spacepacket_header_bytes[SPACEPACKET_ENCODED_HEADER_SIZE];
         for (int i = 0; i < sizeof(spacepacket_header_bytes); i++) {
             xQueueReceive(command_byte_queue, &spacepacket_header_bytes[i], portMAX_DELAY);

--- a/main/tasks/command/command.h
+++ b/main/tasks/command/command.h
@@ -13,6 +13,7 @@
 
 #define COMMAND_MAX_QUEUE_ITEMS 0x200
 #define COMMAND_SYNC_BYTES "\x35\x2E\xF8\x53" 
+#define CALLSIGN_SIZE 8
 
 /**
  * @brief Command Structs and Types

--- a/main/tasks/telemetry/telemetry.c
+++ b/main/tasks/telemetry/telemetry.c
@@ -50,7 +50,6 @@ void telemetry_task(void* unused_arg) {
         // Do not increment if this is a logging packet (GSE only), we want only packets over the radio to increment
         header.packet_sequence_count = (telemetry.apid == 0) ? g_packet_sequence_number : g_packet_sequence_number++;
         header.packet_length = telemetry.payload_size - 1; // 4.1.3.5.3 in spacepacket standard says packet_length - 1
-        full_packet
 
         // Encode spacepacket header into bytes
         size_t header_size = TELEMETRY_SYNC_SIZE + CALLSIGN_SIZE + SPACEPACKET_ENCODED_HEADER_SIZE;

--- a/main/tasks/telemetry/telemetry.h
+++ b/main/tasks/telemetry/telemetry.h
@@ -108,6 +108,7 @@ typedef struct __attribute__((__packed__)) {
     char callsign[8];
      spacepacket_header_t header;
     uint8_t* payload;
+    size_t payload_size;
 } spacepacket_full_t;
 
 

--- a/main/tasks/telemetry/telemetry.h
+++ b/main/tasks/telemetry/telemetry.h
@@ -105,9 +105,9 @@ typedef struct __attribute__((__packed__)) {
 } ack_telemetry_t;
 
 typedef struct __attribute__((__packed__)) {
-    char callsign[8]
-     spacepacket_header_t header
-    uint8_t* payload
+    char callsign[8];
+     spacepacket_header_t header;
+    uint8_t* payload;
 } spacepacket_full_t;
 
 

--- a/main/tasks/telemetry/telemetry.h
+++ b/main/tasks/telemetry/telemetry.h
@@ -12,6 +12,9 @@
 #define TELEMETRY_SYNC_SIZE 4U
 #define TELEMETRY_MAX_QUEUE_ITEMS 128
 #define TELEMETRY_CHECK_DELAY_MS portMAX_DELAY
+#define CALLSIGN_SIZE 8
+
+const char* CALLSIGN = "\0KK7LTW\0\0"; //Use Tyler's callsign for now, also make sure to pad to CALLSIGN_SIZE. A little bit over is fine.
 
 uint16_t g_packet_sequence_number;
 

--- a/main/tasks/telemetry/telemetry.h
+++ b/main/tasks/telemetry/telemetry.h
@@ -104,6 +104,13 @@ typedef struct __attribute__((__packed__)) {
     uint8_t *data; ///< Any extra data that might be returned by a command
 } ack_telemetry_t;
 
+typedef struct __attribute__((__packed__)) {
+    char callsign[8]
+     spacepacket_header_t header
+    uint8_t* payload
+} spacepacket_full_t;
+
+
 /* USER FUNCTIONS */
 void send_telemetry(telemetry_apid_t apid, const char* payload_buffer, size_t payload_size);
 


### PR DESCRIPTION
Essentially, in telemetry_task within telemetry.c we edited the code to insert the callsign in (and push other bytes back to account for it). Then, in command_task within command.c, we edited the code to skip over the callsign bytes when we are collecting the bytes from the queue to parse into a space packet.

Also added macros in telemetry.h and command.h related to the callsign and the size of the callsign in bytes.