### PR TITLE
fixed sx1268 not seeing transmit done interrupts

### DIFF
--- a/main/tasks/radio/radio.cpp
+++ b/main/tasks/radio/radio.cpp
@@ -368,7 +368,7 @@ void radio_task_cpp(){
         // handle interrupt flags 
         if(cad_detected_RFM || operation_done_RFM || general_flag_SX){
             // handle finished transmission
-            if(transmitting && operation_done_RFM){
+            if(transmitting && (operation_done_RFM || general_flag_SX)){
                 transmitting = false; 
                 radio->finishTransmit();
                 #if RADIO_LOGGING


### PR DESCRIPTION
radio interrupt recognizing was set up for RFM98 only, added recognizing sx1268 transmits being done 