### PR TITLE
Better organization of defines to avoid conflicts 

### DIFF
--- a/main/drivers/include/mram.h
+++ b/main/drivers/include/mram.h
@@ -9,34 +9,6 @@
 #include <stdlib.h>
 #include "pico/stdlib.h"
 
-//Project specific constants
-#define SPI_BUS spi1
-#define FREQ 1000000
-#define PACKET_SIZE 8
-#define MAX_BYTES 32768
-
-// PINS ON Raspberry Pi - to be set by electrical team.
-#define SO 8    /// MISO/SDO/SO are all same thing
-#define CS 9 
-#define SCK 10 
-#define SI 11   /// MOSI/SDI/SI are all same thing
-
-
-
-#define WP 0 
-#define HOLD 0
-#define GND 0   /// Wired up to random place
-#define PS 0    /// Wired up to random place
-
-/// Command codes
-#define WREN 0x06
-#define WRDI 0x04
-#define RDSR 0x05
-#define WRSR 0x01
-#define READ 0x03
-#define WRITE 0x02
-#define SLEEP 0xB9
-#define WAKE 0xAB
 
 /**
  * @brief Set up MRAM device 

--- a/main/drivers/src/mram.c
+++ b/main/drivers/src/mram.c
@@ -6,6 +6,33 @@
 #include "log.h"
 #include <stdio.h>
 
+//Project specific constants
+#define SPI_BUS spi1
+#define FREQ 1000000
+#define PACKET_SIZE 8
+#define MAX_BYTES 32768
+
+// PINS ON Raspberry Pi - to be set by electrical team.
+#define SO 8    /// MISO/SDO/SO are all same thing
+#define CS 9 
+#define SCK 10 
+#define SI 11   /// MOSI/SDI/SI are all same thing
+
+#define WP 0 
+#define HOLD 0
+#define GND 0   /// Wired up to random place
+#define PS 0    /// Wired up to random place
+
+/// Command codes
+#define WREN 0x06
+#define WRDI 0x04
+#define RDSR 0x05
+#define WRSR 0x01
+#define READ 0x03
+#define WRITE 0x02
+#define SLEEP 0xB9
+#define WAKE 0xAB
+
 //Global Modifiable Variables
 uint16_t memory_start;
 uint16_t cur_addr;

--- a/main/tasks/radio/radio.cpp
+++ b/main/tasks/radio/radio.cpp
@@ -8,6 +8,47 @@
 #include "spacepacket.h"
 #include "command.h"
 
+// pinout for on breadboard
+// #define RADIO_SX_NSS_PIN 28
+// #define RADIO_SX_DIO1_PIN 15
+// #define RADIO_SX_NRST_PIN 27
+// #define RADIO_SX_BUSY_PIN 5
+
+// #define RADIO_RFM_NSS_PIN 7
+// #define RADIO_RFM_DIO0_PIN 17
+// #define RADIO_RFM_NRST_PIN 22
+// #define RADIO_RFM_DIO1_PIN 26
+
+// pinout for on pcb
+#define RADIO_SX_NSS_PIN 5
+#define RADIO_SX_DIO1_PIN 22
+#define RADIO_SX_NRST_PIN 24
+#define RADIO_SX_BUSY_PIN 23
+
+#define RADIO_RFM_NSS_PIN 17
+#define RADIO_RFM_DIO0_PIN 27
+#define RADIO_RFM_NRST_PIN 20
+#define RADIO_RFM_DIO1_PIN 29
+
+#define RADIO_FREQ 434.0
+#define RADIO_BW 125.0
+#define RADIO_SF 9
+#define RADIO_CR 7
+#define RADIO_SYNC_WORD 18
+#define RADIO_PREAMBLE_LEN 8
+#define RADIO_RFM_GAIN 0
+#define RADIO_SX_TXCO_VOLT 0.0
+#define RADIO_SX_USE_REG_LDO false
+
+#define RADIO_MAX_QUEUE_ITEMS 64
+
+#define RADIO_RF_SWITCH_PIN 12
+#define RADIO_SX_POWER_PIN 7
+#define RADIO_RFM_POWER_PIN 14
+
+#define RADIO_RF_SWITCH_RFM 1
+#define RADIO_RF_SWITCH_SX 0
+
 #define ERR_NONE 0
 #define NULL_QUEUE_WAIT_TIME 100
 

--- a/main/tasks/radio/radio.h
+++ b/main/tasks/radio/radio.h
@@ -12,47 +12,6 @@
 #include "queue.h"
 #include <stdint.h>
 
-// pinout for on breadboard
-// #define RADIO_SX_NSS_PIN 28
-// #define RADIO_SX_DIO1_PIN 15
-// #define RADIO_SX_NRST_PIN 27
-// #define RADIO_SX_BUSY_PIN 5
-
-// #define RADIO_RFM_NSS_PIN 7
-// #define RADIO_RFM_DIO0_PIN 17
-// #define RADIO_RFM_NRST_PIN 22
-// #define RADIO_RFM_DIO1_PIN 26
-
-// pinout for on pcb
-#define RADIO_SX_NSS_PIN 5
-#define RADIO_SX_DIO1_PIN 22
-#define RADIO_SX_NRST_PIN 24
-#define RADIO_SX_BUSY_PIN 23
-
-#define RADIO_RFM_NSS_PIN 17
-#define RADIO_RFM_DIO0_PIN 27
-#define RADIO_RFM_NRST_PIN 20
-#define RADIO_RFM_DIO1_PIN 29
-
-#define RADIO_FREQ 434.0
-#define RADIO_BW 125.0
-#define RADIO_SF 9
-#define RADIO_CR 7
-#define RADIO_SYNC_WORD 18
-#define RADIO_PREAMBLE_LEN 8
-#define RADIO_RFM_GAIN 0
-#define RADIO_SX_TXCO_VOLT 0.0
-#define RADIO_SX_USE_REG_LDO false
-
-#define RADIO_MAX_QUEUE_ITEMS 64
-
-#define RADIO_RF_SWITCH_PIN 12
-#define RADIO_SX_POWER_PIN 7
-#define RADIO_RFM_POWER_PIN 14
-
-#define RADIO_RF_SWITCH_RFM 1
-#define RADIO_RF_SWITCH_SX 0
-
 QueueHandle_t radio_queue;
 
 /// @brief Radio operation types for use in radio_queue_operations_t in the radio_queue


### PR DESCRIPTION
MRAM and Filesystem both define READ, this should move MRAM's into mram.c to avoid that conflict (and does the same type of thing for radio for better org)
