### PR TITLE
Heap 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ set (FREERTOS_SOURCE_FILES
     ${FREERTOS_SRC_DIRECTORY}/stream_buffer.c
     ${FREERTOS_SRC_DIRECTORY}/tasks.c
     ${FREERTOS_SRC_DIRECTORY}/timers.c
-    ${FREERTOS_SRC_DIRECTORY}/portable/MemMang/heap_3.c 
+    ${FREERTOS_SRC_DIRECTORY}/portable/MemMang/heap_4.c 
 )
 
 # Add FreeRTOS source files

--- a/freertos/FreeRTOSConfig.h
+++ b/freertos/FreeRTOSConfig.h
@@ -38,7 +38,7 @@
 #define configSUPPORT_STATIC_ALLOCATION         0
 #define configSUPPORT_DYNAMIC_ALLOCATION        1           // Get FreeRTOS to allocation task memory
 #define configAPPLICATION_ALLOCATED_HEAP        0
-#define configTOTAL_HEAP_SIZE                   240000      // 240 KB 
+#define configTOTAL_HEAP_SIZE                   230000      // 230 KB 
 
 /* Hook function related definitions. */
 #define configUSE_IDLE_HOOK                     0

--- a/freertos/FreeRTOSConfig.h
+++ b/freertos/FreeRTOSConfig.h
@@ -37,7 +37,8 @@
 /* Memory allocation related definitions. */
 #define configSUPPORT_STATIC_ALLOCATION         0
 #define configSUPPORT_DYNAMIC_ALLOCATION        1           // Get FreeRTOS to allocation task memory
-#define configAPPLICATION_ALLOCATED_HEAP        1
+#define configAPPLICATION_ALLOCATED_HEAP        0
+#define configTOTAL_HEAP_SIZE                   240000      // 240 KB 
 
 /* Hook function related definitions. */
 #define configUSE_IDLE_HOOK                     0

--- a/freertos/FreeRTOSConfig.h
+++ b/freertos/FreeRTOSConfig.h
@@ -38,13 +38,13 @@
 #define configSUPPORT_STATIC_ALLOCATION         0
 #define configSUPPORT_DYNAMIC_ALLOCATION        1           // Get FreeRTOS to allocation task memory
 #define configAPPLICATION_ALLOCATED_HEAP        0
-#define configTOTAL_HEAP_SIZE                   230000      // 230 KB 
+#define configTOTAL_HEAP_SIZE                   200000      // 230 KB 
 
 /* Hook function related definitions. */
 #define configUSE_IDLE_HOOK                     0
 #define configUSE_TICK_HOOK                     0
-#define configCHECK_FOR_STACK_OVERFLOW          0
-#define configUSE_MALLOC_FAILED_HOOK            0
+#define configCHECK_FOR_STACK_OVERFLOW          2
+#define configUSE_MALLOC_FAILED_HOOK            1
 #define configUSE_DAEMON_TASK_STARTUP_HOOK      0
 
 /* Run time and task stats gathering related definitions. */

--- a/freertos/FreeRTOSConfig.h
+++ b/freertos/FreeRTOSConfig.h
@@ -38,7 +38,7 @@
 #define configSUPPORT_STATIC_ALLOCATION         0
 #define configSUPPORT_DYNAMIC_ALLOCATION        1           // Get FreeRTOS to allocation task memory
 #define configAPPLICATION_ALLOCATED_HEAP        0
-#define configTOTAL_HEAP_SIZE                   200000      // 230 KB 
+#define configTOTAL_HEAP_SIZE                   200000      // 200 KB 
 
 /* Hook function related definitions. */
 #define configUSE_IDLE_HOOK                     0

--- a/main/tasks/main/main.c
+++ b/main/tasks/main/main.c
@@ -75,7 +75,7 @@ int main() {
 #ifndef SIMULATOR
     radio_task_status = xTaskCreate(radio_task, 
                                          "RADIO", 
-                                         256, 
+                                         512, 
                                          NULL, 
                                          1,
                                          NULL);
@@ -101,4 +101,14 @@ int main() {
     
     // We should never get here, but just in case...
     while(true){};
+}
+
+void vApplicationStackOverflowHook(TaskHandle_t xTask, char *pcTaskName) {
+    // breakpoint to debug, should be able to see pcTaskName in the debugger
+    __asm__("BKPT #0");
+}  
+
+void vApplicationMallocFailedHook( void ) {
+    // see call history in debugger?
+    __asm__("BKPT #0");
 }

--- a/main/tasks/main/main.c
+++ b/main/tasks/main/main.c
@@ -28,7 +28,14 @@
  * ASU Sun Devil Satellite Lab
  */
 
-
+// task create results (avoid using the non FreeRTOS stack)
+static BaseType_t gse_task_status; 
+static BaseType_t scheduler_task_status; 
+static BaseType_t command_task_status;
+static BaseType_t telemetry_task_status;
+static BaseType_t radio_task_status; 
+static BaseType_t filesystem_task_status;
+static BaseType_t watchdog_task_status; 
 
 int main() {
     
@@ -37,28 +44,28 @@ int main() {
 #endif
 
 
-    BaseType_t gse_task_status = xTaskCreate(gse_task, 
+    gse_task_status = xTaskCreate(gse_task, 
                                         "GSE", 
                                         256, 
                                         NULL,
                                         1,
                                         NULL);
          
-    BaseType_t scheduler_task_status = xTaskCreate(steve_task, 
+    scheduler_task_status = xTaskCreate(steve_task, 
                                         "STEVE", 
                                         512, 
                                         NULL, 
                                         1,
                                         NULL);
 
-    BaseType_t command_task_status = xTaskCreate(command_task,
+    command_task_status = xTaskCreate(command_task,
                                         "COMMAND",
                                         1024,
                                         NULL,
                                         1,
                                         NULL);
     
-    BaseType_t telemetry_task_status = xTaskCreate(telemetry_task,
+    telemetry_task_status = xTaskCreate(telemetry_task,
                                         "TELEMETRY",
                                         1024,
                                         NULL,
@@ -66,7 +73,7 @@ int main() {
                                         NULL);
 
 #ifndef SIMULATOR
-    BaseType_t radio_task_status = xTaskCreate(radio_task, 
+    radio_task_status = xTaskCreate(radio_task, 
                                          "RADIO", 
                                          256, 
                                          NULL, 
@@ -75,14 +82,14 @@ int main() {
 #endif
 
 
-    BaseType_t filesystem_task_status = xTaskCreate(filesystem_task,
+    filesystem_task_status = xTaskCreate(filesystem_task,
                                         "FILESYSTEM",
                                         1024,
                                         NULL,
                                         1,
                                         NULL);
 
-    BaseType_t watchdog_task_status = xTaskCreate(watchdog_task,
+    watchdog_task_status = xTaskCreate(watchdog_task,
                                         "WATCHDOG",
                                         1024,
                                         NULL,

--- a/main/tasks/steve/steve.c
+++ b/main/tasks/steve/steve.c
@@ -235,6 +235,10 @@ void initialize_steve() {
     schedule_recurring_job_secs(HEARTBEAT_JOB_NAME, heartbeat_telemetry_job, HEARTBEAT_TELEMETRY_DEFAULT_INTERVAL);
 }
 
+// temp
+size_t heap_size = 0; 
+size_t minimum_ever_heap_size = 0; 
+
 // Main thread job for scheduling and executing STEVE jobs
 void steve_task(void* unused_arg) {
     // Setup STEVE jobs and state
@@ -254,6 +258,12 @@ void steve_task(void* unused_arg) {
 
     // Run main task loop
     while (true) {
+
+        // temp for tracking
+        heap_size = xPortGetFreeHeapSize(); 
+        minimum_ever_heap_size = xPortGetMinimumEverFreeHeapSize(); 
+        
+
         // Take mutex
         xSemaphoreTake(g_steve_context.mutex, portMAX_DELAY);
         // Check each job to see if it needs to be executed


### PR DESCRIPTION
Switches memory management over to FreeRTOS's heap_4 instead of heap_3 with a defined heap size of 200KB. Also expands radio tasks stack size and moves as much out of the Pico SDK stack as possible. 