### PR TITLE
Tyler/hardline connection debug

### DIFF
--- a/main/drivers/src/usb_uart.c
+++ b/main/drivers/src/usb_uart.c
@@ -1,9 +1,14 @@
 #include <unistd.h>
+#include "pico/stdio_usb.h"
 
 #include "usb_uart.h"
 
 int writebytes_usb(uint8_t *buffer, size_t size) {
-    return write(1, buffer, size);
+    // if the usb device is connected, send the data
+    if(stdio_usb_connected()){
+        return write(1, buffer, size);
+    }
+    // otherwise don't 
 }
 
 int readbytes_usb(uint8_t *buffer, size_t size) {

--- a/main/simulator/pico-sdk/pico/stdio_usb.h
+++ b/main/simulator/pico-sdk/pico/stdio_usb.h
@@ -1,6 +1,0 @@
-#pragma once
-#include <stdbool.h>
-
-// including this bc I think it should be needed but I don't think it is 
-// idk 
-bool stdio_usb_connected(void){ return true; }

--- a/main/simulator/pico-sdk/pico/stdio_usb.h
+++ b/main/simulator/pico-sdk/pico/stdio_usb.h
@@ -1,0 +1,6 @@
+#pragma once
+#include <stdbool.h>
+
+// including this bc I think it should be needed but I don't think it is 
+// idk 
+bool stdio_usb_connected(void){ return true; }


### PR DESCRIPTION
Checks the USB connection before adding data to the USB buffer. I believe not doing so has been slowing down the system by blocking gse's `gse_queue_message` function when the usb is not connected. I think the USB buffer is filling up and so the write(...) call is blocking until the pico sdk usb manager fixes it with it's regular management, but I didn't look tons into that, so it may be for other reasons. But the system does run better now with that check in there. 